### PR TITLE
compiler: remove parent's paths from the CheckingError type

### DIFF
--- a/compiler/checker_statements.go
+++ b/compiler/checker_statements.go
@@ -147,14 +147,12 @@ nodesLoop:
 
 			path := tc.path
 			tc.path = node.Tree.Path
-			tc.paths = append(tc.paths, checkerPath{path, node})
 			scopes := tc.scopes
 			tc.scopes = nil
 
 			node.Tree.Nodes = tc.checkNodesInNewScope(node.Tree.Nodes)
 
 			tc.path = path
-			tc.paths = tc.paths[:len(tc.paths)-1]
 			tc.scopes = scopes
 
 		case *ast.Block:

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -219,21 +219,20 @@ type PackageLoader interface {
 // CheckingError records a type checking error with the path and the position
 // where the error occurred.
 type CheckingError struct {
-	path    string
-	parents string
-	pos     ast.Position
-	err     error
+	path string
+	pos  ast.Position
+	err  error
 }
 
 // Error returns a string representation of the type checking error.
 func (e *CheckingError) Error() string {
-	return fmt.Sprintf("%s:%s: %s%s", e.path, e.pos, e.err, e.parents)
+	return fmt.Sprintf("%s:%s: %s", e.path, e.pos, e.err)
 }
 
 // Message returns the message of the type checking error, without position and
 // path.
 func (e *CheckingError) Message() string {
-	return e.err.Error() + e.parents
+	return e.err.Error()
 }
 
 // Path returns the path of the type checking error.


### PR DESCRIPTION
Parent's paths are not useful for resolving a compilation error so this
commit remove them from the CheckingError type.