### PR TITLE
compiler: fix error message returned on cycle in templates

### DIFF
--- a/compiler/parser.go
+++ b/compiler/parser.go
@@ -76,7 +76,7 @@ func syntaxError(pos *ast.Position, format string, a ...interface{}) *SyntaxErro
 type cycleError string
 
 func (e cycleError) Error() string {
-	return fmt.Sprintf("cycle not allowed\n%s", string(e))
+	return string(e)
 }
 
 // containsOnlySpaces reports whether b contains only white space characters

--- a/compiler/parser_cycle_test.go
+++ b/compiler/parser_cycle_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2020 Open2b Software Snc. All rights reserved.
+// https://www.open2b.com
+
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package compiler
+
+import (
+	"testing"
+
+	"github.com/open2b/scriggo/compiler/ast"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var cyclicProgram = mapStringLoader{
+	"main":       "package main\nimport _ \"cycle/foo\"\nfunc main() {}",
+	"cycle/foo":  "package foo\nimport _ \"cycle/foo2\"",
+	"cycle/foo2": "package foo2\nimport _ \"cycle/foo3\"",
+	"cycle/foo3": "package foo3\nimport _ \"cycle/foo\"",
+}
+
+const cyclicProgramErrorMessage = `package main
+	imports cycle/foo
+	imports cycle/foo2
+	imports cycle/foo3
+	imports cycle/foo: import cycle not allowed`
+
+func TestCyclicProgram(t *testing.T) {
+	_, err := ParseProgram(cyclicProgram)
+	if err == nil {
+		t.Fatal("expecting cycle error, got no error")
+	}
+	if diff := cmp.Diff(cyclicProgramErrorMessage, err.Error()); diff != "" {
+		t.Fatalf("unexpected error message (-want, +got):\n%s", diff)
+	}
+}
+
+var cyclicTemplate = mapStringReader{
+	"/index.html":            `{% extends "/layout.html" %}`,
+	"/layout.html":           `{% import "/macros/macro.html" %}`,
+	"/includes/include.html": `{% import "/macros/macro.html" %}`,
+	"/macros/macro.html":     `{% macro A() %}\n\t{% include "/includes/include.html" %}\n{% end %}`,
+}
+
+const cyclicTemplateErrorMessage = `file /index.html
+	extends  /layout.html
+	imports  /macros/macro.html
+	includes /includes/include.html
+	imports  /macros/macro.html: cycle not allowed`
+
+func TestTCyclicTemplate(t *testing.T) {
+	_, err := ParseTemplate("index.html", cyclicTemplate, ast.LanguageHTML, false, nil)
+	if err == nil {
+		t.Fatal("expecting cycle error, got no error")
+	}
+	if diff := cmp.Diff(cyclicTemplateErrorMessage, err.Error()); diff != "" {
+		t.Fatalf("unexpected error message (-want, +got):\n%s", diff)
+	}
+}
+
+type mapStringReader map[string]string
+
+func (r mapStringReader) ReadFile(name string) ([]byte, error) {
+	src, ok := r[name]
+	if !ok {
+		panic("not existing")
+	}
+	return []byte(src), nil
+}

--- a/compiler/parser_program.go
+++ b/compiler/parser_program.go
@@ -88,7 +88,7 @@ func ParseProgram(packages PackageLoader) (*ast.Tree, error) {
 								}
 								err += imp.Path
 							}
-							err += "\n\timports " + p.Path
+							err += "\n\timports " + p.Path + ": import cycle not allowed"
 							return nil, cycleError(err)
 						}
 					}

--- a/compiler/parser_template.go
+++ b/compiler/parser_template.go
@@ -55,7 +55,7 @@ func ParseTemplate(path string, reader FileReader, lang ast.Language, relaxedBoo
 		if err2, ok := err.(*SyntaxError); ok && err2.path == "" {
 			err2.path = path
 		} else if err2, ok := err.(cycleError); ok {
-			err = cycleError(path + "\n\t" + string(err2))
+			err = cycleError("file " + path + string(err2) + ": cycle not allowed")
 		} else if os.IsNotExist(err) {
 			err = ErrNotExist
 		}
@@ -94,7 +94,7 @@ func (pp *templateExpansion) parseFile(name string, lang ast.Language) (*ast.Tre
 	// Check if there is a cycle.
 	for _, p := range pp.paths {
 		if p == name {
-			return nil, cycleError(name)
+			return nil, cycleError("")
 		}
 	}
 
@@ -229,7 +229,7 @@ func (pp *templateExpansion) expand(nodes []ast.Node) error {
 				} else if os.IsNotExist(err) {
 					err = syntaxError(n.Pos(), "extends path %q does not exist", absPath)
 				} else if err2, ok := err.(cycleError); ok {
-					err = cycleError("imports " + string(err2))
+					err = cycleError("\n\textends  " + absPath + string(err2))
 				}
 				return err
 			}
@@ -265,7 +265,7 @@ func (pp *templateExpansion) expand(nodes []ast.Node) error {
 					} else if os.IsNotExist(err) {
 						err = syntaxError(n.Pos(), "import path %q does not exist", absPath)
 					} else if err2, ok := err.(cycleError); ok {
-						err = cycleError("imports " + string(err2))
+						err = cycleError("\n\timports  " + absPath + string(err2))
 					}
 					return err
 				}
@@ -284,7 +284,7 @@ func (pp *templateExpansion) expand(nodes []ast.Node) error {
 				} else if os.IsNotExist(err) {
 					err = syntaxError(n.Pos(), "included path %q does not exist", absPath)
 				} else if err2, ok := err.(cycleError); ok {
-					err = cycleError("include " + string(err2))
+					err = cycleError("\n\tincludes " + absPath + string(err2))
 				}
 				return err
 			}


### PR DESCRIPTION
This commit fixes the error message returned if there is a cycle parsing
a template file. So instead of:

```
cycle not allowed
/index.html
	imports imports include imports /includes/macro.html
```

the following error message is returned:

```
file /index.html
	extents  /layout.html
	imports  /includes/macro.html
	includes /includes/include.html
	imports  /includes/macro.html: cycle not allowed
```

It also changes the error message on cycles in programs moving the text
"import cycle not allowed" at the end of the message as gc does.