### PR TITLE
compiler/parser: don't allow comments in {% %} and {{ }}

### DIFF
--- a/compiler/lexer.go
+++ b/compiler/lexer.go
@@ -856,6 +856,12 @@ LOOP:
 			}
 		case '/':
 			if len(l.src) > 1 && l.src[1] == '/' {
+				if end == tokenEndStatement {
+					return l.errorf("comments in {%% %%} not allowed")
+				}
+				if end == tokenRightBraces {
+					return l.errorf("comments in {{ }} not allowed")
+				}
 				p := bytes.Index(l.src, []byte("\n"))
 				if p == -1 {
 					break LOOP
@@ -870,6 +876,12 @@ LOOP:
 				continue LOOP
 			}
 			if len(l.src) > 1 && l.src[1] == '*' {
+				if end == tokenEndStatement {
+					return l.errorf("comments in {%% %%} not allowed")
+				}
+				if end == tokenRightBraces {
+					return l.errorf("comments in {{ }} not allowed")
+				}
 				p := bytes.Index(l.src, []byte("*/"))
 				if p == -1 {
 					return l.errorf("comment not terminated")

--- a/templates/template_test.go
+++ b/templates/template_test.go
@@ -826,18 +826,45 @@ var templateMultiPageCases = map[string]struct {
 		expectedOut: `3`,
 	},
 
-	"Multi rows with comments": {
+	"Comments // between {% and %}": {
 		sources: map[string]string{
 			"index.html": `{%
 // pre comment
-/* pre comment */
 	print(3)
-/* post comment */
-// post comment
-
 %}`,
 		},
-		expectedOut: `3`,
+		expectedLoadErr: `comments in {% %} not allowed`,
+	},
+
+	"Comments /* */ between {% and %}": {
+		sources: map[string]string{
+			"index.html": `{% /* pre comment */ print(3) %}`,
+		},
+		expectedLoadErr: `comments in {% %} not allowed`,
+	},
+
+	"Comments /* */ in {% and %} (2)": {
+		sources: map[string]string{
+			"index.html": `{% print(6 /* pre comment */ 3) %}`,
+		},
+		expectedLoadErr: `comments in {% %} not allowed`,
+	},
+
+	"Comments // between {{ and }}": {
+		sources: map[string]string{
+			"index.html": `{{
+	// comment
+	5
+}}`,
+		},
+		expectedLoadErr: `comments in {{ }} not allowed`,
+	},
+
+	"Comments /* */ between {{ and }}": {
+		sources: map[string]string{
+			"index.html": `{{ /* comment */ 5 }}`,
+		},
+		expectedLoadErr: `comments in {{ }} not allowed`,
 	},
 
 	"Using a function declared in main": {


### PR DESCRIPTION
This change does not allow comments in statement {% ... %} and in a show
{{ ... }}.

Closes #693