### PR TITLE
compiler/checker: move show check logic out of the compiler

### DIFF
--- a/compiler/checker.go
+++ b/compiler/checker.go
@@ -9,11 +9,17 @@ package compiler
 import (
 	"errors"
 	"fmt"
+	"io"
 	"reflect"
 
 	"github.com/open2b/scriggo/compiler/ast"
 	"github.com/open2b/scriggo/compiler/types"
+	"github.com/open2b/scriggo/runtime"
 )
+
+type RenderFunc func(runtime.Env, io.Writer, interface{}, ast.Context)
+
+type RenderTypeError error
 
 // checkingMod represents the checking modality.
 type checkingMod int
@@ -142,6 +148,9 @@ type checkerOptions struct {
 
 	// globals.
 	globals Declarations
+
+	// render function.
+	renderFunc RenderFunc
 }
 
 // typechecker represents the state of the type checking.

--- a/compiler/checker_expressions.go
+++ b/compiler/checker_expressions.go
@@ -30,7 +30,6 @@ var boolType = reflect.TypeOf(false)
 var uintType = reflect.TypeOf(uint(0))
 var uint8Type = reflect.TypeOf(uint8(0))
 var int32Type = reflect.TypeOf(int32(0))
-var byteSliceType = reflect.TypeOf([]byte(nil))
 
 var uint8TypeInfo = &typeInfo{Type: uint8Type, Properties: propertyIsType | propertyPredeclared}
 var int32TypeInfo = &typeInfo{Type: int32Type, Properties: propertyIsType | propertyPredeclared}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -44,6 +44,7 @@ type Options struct {
 	AllowShebangLine bool
 	DisallowGoStmt   bool
 	Globals          Declarations
+	RenderFunc       RenderFunc
 
 	// Packages loads Scriggo packages and precompiled packages.
 	//
@@ -175,6 +176,7 @@ func CompileTemplate(path string, r FileReader, lang ast.Language, opts Options)
 		allowNotUsed:   true,
 		disallowGoStmt: opts.DisallowGoStmt,
 		globals:        opts.Globals,
+		renderFunc:     opts.RenderFunc,
 		modality:       templateMod,
 	}
 	tci, err := typecheck(tree, opts.Packages, checkerOpts)

--- a/templates/render.go
+++ b/templates/render.go
@@ -17,6 +17,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/open2b/scriggo/compiler"
 	"github.com/open2b/scriggo/compiler/ast"
 	"github.com/open2b/scriggo/runtime"
 )
@@ -32,13 +33,22 @@ func (err PrintTypeError) Error() string {
 }
 func (err PrintTypeError) RuntimeError() {}
 
-// render renders value in the context ctx and writes to out.
+// render renders value in the context ctx and writes to out. If env and out
+// are nil, it does not render the value but only checks that the type of
+// value can be rendered.
 //
-// Keep in sync with scriggo/compiler.renderFuncType.
-//
+// render has type scriggo/compiler.RenderFunc.
 func render(env runtime.Env, out io.Writer, value interface{}, ctx ast.Context) {
 
 	var err error
+
+	if env == nil && out == nil {
+		err = printedAs(reflect.TypeOf(value), ctx)
+		if err != nil {
+			panic(compiler.RenderTypeError(err))
+		}
+		return
+	}
 
 	switch ctx {
 	case ast.ContextText:

--- a/templates/render_check.go
+++ b/templates/render_check.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2019 Open2b Software Snc. All rights reserved.
+// https://www.open2b.com
+
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package templates
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/open2b/scriggo/compiler/ast"
+)
+
+var emptyInterfaceType = reflect.TypeOf(&[]interface{}{interface{}(nil)}[0]).Elem()
+
+var stringerType = reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
+var envStringerType = reflect.TypeOf((*EnvStringer)(nil)).Elem()
+
+var htmlStringerType = reflect.TypeOf((*HTMLStringer)(nil)).Elem()
+var htmlEnvStringerType = reflect.TypeOf((*HTMLEnvStringer)(nil)).Elem()
+
+var cssStringerType = reflect.TypeOf((*CSSStringer)(nil)).Elem()
+var cssEnvStringerType = reflect.TypeOf((*CSSEnvStringer)(nil)).Elem()
+
+var jsStringerType = reflect.TypeOf((*JSStringer)(nil)).Elem()
+var jsEnvStringerType = reflect.TypeOf((*JSEnvStringer)(nil)).Elem()
+
+var jsonStringerType = reflect.TypeOf((*JSONStringer)(nil)).Elem()
+var jsonEnvStringerType = reflect.TypeOf((*JSONEnvStringer)(nil)).Elem()
+
+var timeType = reflect.TypeOf(time.Time{})
+
+var errorType = reflect.TypeOf((*error)(nil)).Elem()
+
+// printedAs reports whether a type can be printed in context ctx.
+func printedAs(t reflect.Type, ctx ast.Context) error {
+	kind := t.Kind()
+	switch ctx {
+	case ast.ContextText, ast.ContextTag, ast.ContextQuotedAttr, ast.ContextUnquotedAttr,
+		ast.ContextCSSString, ast.ContextJSString, ast.ContextJSONString:
+		switch {
+		case kind == reflect.String:
+		case reflect.Bool <= kind && kind <= reflect.Complex128:
+		case ctx == ast.ContextCSSString && t == byteSliceType:
+		case t.Implements(stringerType):
+		case t.Implements(envStringerType):
+		case t.Implements(errorType):
+		default:
+			return fmt.Errorf("type %s cannot be printed as text", t)
+		}
+	case ast.ContextHTML:
+		switch {
+		case kind == reflect.String:
+		case reflect.Bool <= kind && kind <= reflect.Complex128:
+		case t == byteSliceType:
+		case t.Implements(stringerType):
+		case t.Implements(envStringerType):
+		case t.Implements(htmlStringerType):
+		case t.Implements(htmlEnvStringerType):
+		case t.Implements(errorType):
+		default:
+			return fmt.Errorf("type %s cannot be printed as HTML", t)
+		}
+	case ast.ContextCSS:
+		switch {
+		case kind == reflect.String:
+		case reflect.Int <= kind && kind <= reflect.Float64:
+		case t == byteSliceType:
+		case t.Implements(stringerType):
+		case t.Implements(envStringerType):
+		case t.Implements(cssStringerType):
+		case t.Implements(cssEnvStringerType):
+		case t.Implements(errorType):
+		default:
+			return fmt.Errorf("type %s cannot be printed as CSS", t)
+		}
+	case ast.ContextJS:
+		return printedAsJS(t)
+	case ast.ContextJSON:
+		return printedAsJSON(t)
+	default:
+		panic("unexpected context")
+	}
+	return nil
+}
+
+// printedAsJS reports whether a type can be printed as JavaScript. It returns
+// an error if the type cannot be printed.
+func printedAsJS(t reflect.Type) error {
+	kind := t.Kind()
+	if reflect.Bool <= kind && kind <= reflect.Float64 || kind == reflect.String ||
+		t == timeType ||
+		t.Implements(jsStringerType) ||
+		t.Implements(jsEnvStringerType) ||
+		t.Implements(errorType) {
+		return nil
+	}
+	switch kind {
+	case reflect.Array:
+		if err := printedAsJS(t.Elem()); err != nil {
+			return fmt.Errorf("array of %s cannot be printed as JavaScript", t.Elem())
+		}
+	case reflect.Interface:
+	case reflect.Map:
+		key := t.Key().Kind()
+		switch {
+		case key == reflect.String:
+		case reflect.Bool <= key && key <= reflect.Complex128:
+		case t.Implements(stringerType):
+		case t.Implements(envStringerType):
+		default:
+			return fmt.Errorf("map with %s key cannot be printed as JavaScript", t.Key())
+		}
+		err := printedAsJS(t.Elem())
+		if err != nil {
+			return fmt.Errorf("map with %s element cannot be printed as JavaScript", t.Elem())
+		}
+	case reflect.Ptr, reflect.UnsafePointer:
+		return printedAsJS(t.Elem())
+	case reflect.Slice:
+		if err := printedAsJS(t.Elem()); err != nil {
+			return fmt.Errorf("slice of %s cannot be printed as JavaScript", t.Elem())
+		}
+	case reflect.Struct:
+		n := t.NumField()
+		for i := 0; i < n; i++ {
+			field := t.Field(i)
+			if field.PkgPath == "" {
+				if err := printedAsJS(field.Type); err != nil {
+					return fmt.Errorf("struct containing %s cannot be printed as JavaScript", field.Type)
+				}
+			}
+		}
+	default:
+		return fmt.Errorf("type %s cannot be printed as JavaScript", t)
+	}
+	return nil
+}
+
+// printedAsJSON reports whether a type can be printed as JSON. It returns an
+// error if the type cannot be printed.
+func printedAsJSON(t reflect.Type) error {
+	kind := t.Kind()
+	if reflect.Bool <= kind && kind <= reflect.Float64 || kind == reflect.String ||
+		t == timeType ||
+		t.Implements(jsonStringerType) ||
+		t.Implements(jsonEnvStringerType) ||
+		t.Implements(errorType) {
+		return nil
+	}
+	switch kind {
+	case reflect.Array:
+		if err := printedAsJSON(t.Elem()); err != nil {
+			return fmt.Errorf("array of %s cannot be printed as JSON", t.Elem())
+		}
+	case reflect.Interface:
+	case reflect.Map:
+		key := t.Key().Kind()
+		switch {
+		case key == reflect.String:
+		case reflect.Bool <= key && key <= reflect.Complex128:
+		case t.Implements(stringerType):
+		case t.Implements(envStringerType):
+		default:
+			return fmt.Errorf("map with %s key cannot be printed as JSON", t.Key())
+		}
+		err := printedAsJSON(t.Elem())
+		if err != nil {
+			return fmt.Errorf("map with %s element cannot be printed as JSON", t.Elem())
+		}
+	case reflect.Ptr, reflect.UnsafePointer:
+		return printedAsJSON(t.Elem())
+	case reflect.Slice:
+		if err := printedAsJSON(t.Elem()); err != nil {
+			return fmt.Errorf("slice of %s cannot be printed as JSON", t.Elem())
+		}
+	case reflect.Struct:
+		n := t.NumField()
+		for i := 0; i < n; i++ {
+			field := t.Field(i)
+			if field.PkgPath == "" {
+				if err := printedAsJSON(field.Type); err != nil {
+					return fmt.Errorf("struct containing %s cannot be printed as JSON", field.Type)
+				}
+			}
+		}
+	default:
+		return fmt.Errorf("type %s cannot be printed as JSON", t)
+	}
+	return nil
+}

--- a/templates/template.go
+++ b/templates/template.go
@@ -173,7 +173,7 @@ type CompilerError interface {
 // Load loads a template given its file name. Load calls the method ReadFile of
 // files to read the files of the template.
 func Load(name string, files FileReader, lang Language, options *LoadOptions) (*Template, error) {
-	co := compiler.Options{}
+	co := compiler.Options{RenderFunc: render}
 	if options != nil {
 		co.Globals = compiler.Declarations(options.Globals)
 		co.TreeTransformer = options.TreeTransformer

--- a/test/compare/cmd/template.go
+++ b/test/compare/cmd/template.go
@@ -22,6 +22,7 @@ import (
 	"github.com/open2b/scriggo/compiler"
 	"github.com/open2b/scriggo/compiler/ast"
 	"github.com/open2b/scriggo/runtime"
+	"github.com/open2b/scriggo/templates"
 )
 
 type mapReader map[string][]byte
@@ -190,7 +191,7 @@ func toString(v reflect.Value) string {
 func renderInHTML(out io.Writer, value interface{}) error {
 	w := newStringWriter(out)
 	switch v := value.(type) {
-	case compiler.HTMLStringer:
+	case templates.HTMLStringer:
 		_, err := w.WriteString(v.HTML())
 		return err
 	case fmt.Stringer:


### PR DESCRIPTION
This change moves the 'show' expression checking from the compiler to
the templates package.