### PR TITLE
templates: get file language from file extension by default

### DIFF
--- a/compiler/checker_template_test.go
+++ b/compiler/checker_template_test.go
@@ -9,8 +9,6 @@ package compiler
 import (
 	"strings"
 	"testing"
-
-	"github.com/open2b/scriggo/compiler/ast"
 )
 
 var templateCases = []struct {
@@ -175,7 +173,7 @@ func TestTemplate(t *testing.T) {
 		expected := cas.expected
 		t.Run(src, func(t *testing.T) {
 			r := mapStringReader{"/index.html": src}
-			_, err := CompileTemplate("/index.html", r, ast.LanguageHTML, Options{})
+			_, err := CompileTemplate("/index.html", r, Options{})
 			switch {
 			case expected == "" && err != nil:
 				t.Fatalf("unexpected error: %q", err)

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -147,18 +147,17 @@ func CompileScript(r io.Reader, packages PackageLoader, opts Options) (*Code, er
 	return code, err
 }
 
-// CompileTemplate compiles the template file with the given path and written
-// in language lang. It reads the template files from the reader. path, if not
-// absolute, is relative to the root of the template. lang can be Text, HTML,
-// CSS or JavaScript.
-// Any error related to the compilation itself is returned as a CompilerError.
-func CompileTemplate(path string, r FileReader, lang ast.Language, opts Options) (*Code, error) {
+// CompileTemplate compiles the template file with the given path. It reads
+// the template files from the reader. path, if not absolute, is relative to
+// the root of the template. Any error related to the compilation itself is
+// returned as a CompilerError.
+func CompileTemplate(path string, r FileReader, opts Options) (*Code, error) {
 
 	var tree *ast.Tree
 
 	// Parse the source code.
 	var err error
-	tree, err = ParseTemplate(path, r, lang, opts.Packages)
+	tree, err = ParseTemplate(path, r, opts.Packages)
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/parser.go
+++ b/compiler/parser.go
@@ -17,7 +17,7 @@ import (
 )
 
 type FileReader interface {
-	ReadFile(name string) ([]byte, error)
+	ReadFile(name string) ([]byte, ast.Language, error)
 }
 
 var (

--- a/compiler/parser_cycle_test.go
+++ b/compiler/parser_cycle_test.go
@@ -7,6 +7,7 @@
 package compiler
 
 import (
+	"path"
 	"testing"
 
 	"github.com/open2b/scriggo/compiler/ast"
@@ -169,7 +170,7 @@ var cycleTemplateTests = []struct {
 func TestCyclicTemplates(t *testing.T) {
 	for _, test := range cycleTemplateTests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := ParseTemplate("index.html", test.template, ast.LanguageHTML, nil)
+			_, err := ParseTemplate("index.html", test.template, nil)
 			if err == nil {
 				t.Fatal("expecting cycle error, got no error")
 			}
@@ -192,10 +193,21 @@ func TestCyclicTemplates(t *testing.T) {
 
 type mapStringReader map[string]string
 
-func (r mapStringReader) ReadFile(name string) ([]byte, error) {
+func (r mapStringReader) ReadFile(name string) ([]byte, ast.Language, error) {
 	src, ok := r[name]
 	if !ok {
 		panic("not existing")
 	}
-	return []byte(src), nil
+	language := ast.LanguageText
+	switch path.Ext(name) {
+	case ".html":
+		language = ast.LanguageHTML
+	case ".css":
+		language = ast.LanguageCSS
+	case ".js":
+		language = ast.LanguageJS
+	case ".json":
+		language = ast.LanguageJSON
+	}
+	return []byte(src), language, nil
 }

--- a/templates/escapers_test.go
+++ b/templates/escapers_test.go
@@ -204,7 +204,7 @@ func TestURLEscape(t *testing.T) {
 			opts := &LoadOptions{
 				Globals: globals(),
 			}
-			templ, err := Load("index.html", r, LanguageHTML, opts)
+			templ, err := Load("index.html", r, opts)
 			if err != nil {
 				t.Fatalf("compilation error: %s", err)
 			}

--- a/templates/full_template_test.go
+++ b/templates/full_template_test.go
@@ -15,7 +15,7 @@ func TestFullTemplate(t *testing.T) {
 	r := DirReader("./full_template_test")
 	for page, expectedOutput := range expectedPagesOutput {
 		t.Run(page, func(t *testing.T) {
-			templ, err := Load(page, r, LanguageHTML, nil)
+			templ, err := Load(page, r, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/templates/show_env_test.go
+++ b/templates/show_env_test.go
@@ -77,7 +77,7 @@ var envStringerCases = map[string]struct {
 }{
 	"EnvStringer": {
 		sources: map[string]string{
-			"index.html": "value read from env is {{ v }}",
+			"index.txt": "value read from env is {{ v }}",
 		},
 		globals: map[string]interface{}{
 			"v": &testEnvStringerValue,
@@ -97,7 +97,7 @@ var envStringerCases = map[string]struct {
 	},
 	"CSSEnvStringer": {
 		sources: map[string]string{
-			"index.html": "border-radius: {{ v }};",
+			"index.css": "border-radius: {{ v }};",
 		},
 		globals: map[string]interface{}{
 			"v": &testCSSEnvStringerValue,
@@ -107,7 +107,7 @@ var envStringerCases = map[string]struct {
 	},
 	"JSEnvStringer": {
 		sources: map[string]string{
-			"index.html": "var x = {{ v }};",
+			"index.js": "var x = {{ v }};",
 		},
 		globals: map[string]interface{}{
 			"v": &testJSEnvStringerValue,
@@ -117,7 +117,7 @@ var envStringerCases = map[string]struct {
 	},
 	"JSONEnvStringer": {
 		sources: map[string]string{
-			"index.html": "var x = {{ v }};",
+			"index.json": "var x = {{ v }};",
 		},
 		globals: map[string]interface{}{
 			"v": &testJSONEnvStringerValue,
@@ -146,7 +146,18 @@ func TestEnvStringer(t *testing.T) {
 			opts := &LoadOptions{
 				Globals: cas.globals,
 			}
-			template, err := Load("index.html", r, cas.language, opts)
+			name := "index.txt"
+			switch cas.language {
+			case LanguageHTML:
+				name = "index.html"
+			case LanguageCSS:
+				name = "index.css"
+			case LanguageJS:
+				name = "index.js"
+			case LanguageJSON:
+				name = "index.json"
+			}
+			template, err := Load(name, r, opts)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/templates/show_test.go
+++ b/templates/show_test.go
@@ -54,7 +54,7 @@ func TestHTMLContext(t *testing.T) {
 		opts := &LoadOptions{
 			Globals: asDeclarations(expr.vars),
 		}
-		tmpl, err := Load("index.html", r, LanguageHTML, opts)
+		tmpl, err := Load("index.html", r, opts)
 		if err != nil {
 			t.Errorf("source: %q, %s\n", expr.src, err)
 			continue
@@ -109,7 +109,7 @@ func TestQuotedAttrContext(t *testing.T) {
 		opts := &LoadOptions{
 			Globals: asDeclarations(expr.vars),
 		}
-		tmpl, err := Load("index.html", r, LanguageHTML, opts)
+		tmpl, err := Load("index.html", r, opts)
 		if err != nil {
 			t.Errorf("source: %q, %s\n", expr.src, err)
 			continue
@@ -146,7 +146,7 @@ func TestUnquotedAttrContext(t *testing.T) {
 		opts := &LoadOptions{
 			Globals: asDeclarations(expr.vars),
 		}
-		tmpl, err := Load("index.html", r, LanguageHTML, opts)
+		tmpl, err := Load("index.html", r, opts)
 		if err != nil {
 			t.Errorf("source: %q, %s\n", expr.src, err)
 			continue
@@ -228,7 +228,7 @@ func TestScriptContext(t *testing.T) {
 			opts := &LoadOptions{
 				Globals: asDeclarations(expr.vars),
 			}
-			tmpl, err := Load("index.html", r, LanguageHTML, opts)
+			tmpl, err := Load("index.html", r, opts)
 			if err != nil {
 				t.Errorf("type: %s, source: %q, %s\n", typ, expr.src, err)
 				continue
@@ -261,7 +261,7 @@ func TestJSContext(t *testing.T) {
 		opts := &LoadOptions{
 			Globals: asDeclarations(expr.vars),
 		}
-		tmpl, err := Load("index.html", r, LanguageHTML, opts)
+		tmpl, err := Load("index.html", r, opts)
 		if err != nil {
 			t.Errorf("source: %q, %s\n", expr.src, err)
 			continue
@@ -293,7 +293,7 @@ func TestJSONContext(t *testing.T) {
 		opts := &LoadOptions{
 			Globals: asDeclarations(expr.vars),
 		}
-		tmpl, err := Load("index.html", r, LanguageHTML, opts)
+		tmpl, err := Load("index.html", r, opts)
 		if err != nil {
 			t.Errorf("source: %q, %s\n", expr.src, err)
 			continue
@@ -351,7 +351,7 @@ func TestJSStringContext(t *testing.T) {
 			opts := &LoadOptions{
 				Globals: asDeclarations(expr.vars),
 			}
-			tmpl, err := Load("index.html", r, LanguageHTML, opts)
+			tmpl, err := Load("index.html", r, opts)
 			if err != nil {
 				t.Errorf("source: %q, %s\n", expr.src, err)
 				continue
@@ -390,7 +390,7 @@ func TestCSSContext(t *testing.T) {
 		opts := &LoadOptions{
 			Globals: asDeclarations(expr.vars),
 		}
-		tmpl, err := Load("index.html", r, LanguageHTML, opts)
+		tmpl, err := Load("index.html", r, opts)
 		if err != nil {
 			t.Errorf("source: %q, %s\n", expr.src, err)
 			continue
@@ -440,7 +440,7 @@ func TestCSSStringContext(t *testing.T) {
 			opts := &LoadOptions{
 				Globals: asDeclarations(expr.vars),
 			}
-			tmpl, err := Load("index.html", r, LanguageHTML, opts)
+			tmpl, err := Load("index.html", r, opts)
 			if err != nil {
 				t.Errorf("source: %q, %s\n", expr.src, err)
 				continue

--- a/templates/transformer_test.go
+++ b/templates/transformer_test.go
@@ -25,7 +25,7 @@ func Test_treeTransformer(t *testing.T) {
 			return nil
 		},
 	}
-	template, err := Load("index.html", reader, LanguageText, loadOpts)
+	template, err := Load("index.html", reader, loadOpts)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This commit changes the Load method to read the file's language from the
file's extension by default. If the provided FileReader implements the
method 'Language(string) (Language, error)', this method is called to
get the language of the file.

Consequently the compiler.FileReader.ReadFile method is changed to
return the language of the file.