### PR TITLE
all: replaces 'show' statements with a single 'show' statement

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -735,19 +735,6 @@ func NewTypeDeclaration(pos *Position, ident *Identifier, typ Expression, isAlia
 	return &TypeDeclaration{pos, ident, typ, isAliasDeclaration}
 }
 
-// ShowMacro node represents a statement "show <macro>".
-type ShowMacro struct {
-	*Position               // position in the source.
-	Macro      Expression   // macro.
-	Args       []Expression // arguments.
-	IsVariadic bool         // reports whether it is variadic.
-	Context    Context      // context.
-}
-
-func NewShowMacro(pos *Position, macro Expression, args []Expression, isVariadic bool, ctx Context) *ShowMacro {
-	return &ShowMacro{Position: pos, Macro: macro, Args: args, IsVariadic: isVariadic, Context: ctx}
-}
-
 // Partial node represents a statement "partial <path>".
 type Partial struct {
 	*Position         // position in the source.
@@ -760,7 +747,7 @@ func NewPartial(pos *Position, path string, ctx Context) *Partial {
 	return &Partial{Position: pos, Path: path, Context: ctx}
 }
 
-// Show node represents statements {{ ... }} and "show(<expr>)".
+// Show node represents statements {{ ... }} and "show <expr>".
 type Show struct {
 	*Position            // position in the source.
 	Expr      Expression // expression that once evaluated returns the value to show.

--- a/compiler/ast/astutil/clone.go
+++ b/compiler/ast/astutil/clone.go
@@ -212,17 +212,6 @@ func CloneNode(node ast.Node) ast.Node {
 	case *ast.Show:
 		return ast.NewShow(ClonePosition(n.Position), CloneExpression(n.Expr), n.Context)
 
-	case *ast.ShowMacro:
-		var macro = CloneExpression(n.Macro)
-		var arguments []ast.Expression
-		if n.Args != nil {
-			arguments = make([]ast.Expression, len(n.Args))
-			for i, a := range n.Args {
-				arguments[i] = CloneExpression(a)
-			}
-		}
-		return ast.NewShowMacro(ClonePosition(n.Position), macro, arguments, n.IsVariadic, n.Context)
-
 	case *ast.Statements:
 		var nodes []ast.Node
 		if n.Nodes != nil {

--- a/compiler/ast/astutil/walk.go
+++ b/compiler/ast/astutil/walk.go
@@ -276,7 +276,6 @@ func Walk(v Visitor, node ast.Node) {
 
 	case *ast.BasicLiteral,
 		*ast.Identifier,
-		*ast.ShowMacro,
 		*ast.Comment,
 		*ast.Text,
 		*ast.Placeholder,

--- a/compiler/builder_instructions.go
+++ b/compiler/builder_instructions.go
@@ -115,18 +115,25 @@ func (builder *functionBuilder) emitBreak(lab label) {
 	builder.fn.Body = append(builder.fn.Body, runtime.Instruction{Op: runtime.OpBreak, A: a, B: b, C: c})
 }
 
-// emitCall appends a new "Call" instruction to the function body.
+// emitCallFunc appends a new "CallFunc" instruction to the function body.
 //
 //     p.f()
 //
-func (builder *functionBuilder) emitCall(f int8, shift runtime.StackShift, pos *ast.Position, buffer bool) {
+func (builder *functionBuilder) emitCallFunc(f int8, shift runtime.StackShift, pos *ast.Position) {
 	builder.addPosAndPath(pos)
 	fn := builder.fn
-	var b int8
-	if buffer {
-		b = 1
-	}
-	fn.Body = append(fn.Body, runtime.Instruction{Op: runtime.OpCall, A: f, B: b})
+	fn.Body = append(fn.Body, runtime.Instruction{Op: runtime.OpCallFunc, A: f})
+	fn.Body = append(fn.Body, runtime.Instruction{Op: runtime.Operation(shift[0]), A: shift[1], B: shift[2], C: shift[3]})
+}
+
+// emitCallMacro appends a new "CallMacro" instruction to the function body.
+//
+//     p.m()
+//
+func (builder *functionBuilder) emitCallMacro(f int8, shift runtime.StackShift, pos *ast.Position, toFormat ast.Format) {
+	builder.addPosAndPath(pos)
+	fn := builder.fn
+	fn.Body = append(fn.Body, runtime.Instruction{Op: runtime.OpCallMacro, A: f, B: int8(toFormat)})
 	fn.Body = append(fn.Body, runtime.Instruction{Op: runtime.Operation(shift[0]), A: shift[1], B: shift[2], C: shift[3]})
 }
 
@@ -134,15 +141,11 @@ func (builder *functionBuilder) emitCall(f int8, shift runtime.StackShift, pos *
 //
 //     f()
 //
-func (builder *functionBuilder) emitCallIndirect(f int8, numVariadic int8, shift runtime.StackShift, pos *ast.Position, funcType reflect.Type, buffer bool) {
+func (builder *functionBuilder) emitCallIndirect(f int8, numVariadic int8, shift runtime.StackShift, pos *ast.Position, funcType reflect.Type) {
 	builder.addPosAndPath(pos)
 	builder.addFunctionType(funcType)
 	fn := builder.fn
-	var b int8
-	if buffer {
-		b = 1
-	}
-	fn.Body = append(fn.Body, runtime.Instruction{Op: runtime.OpCallIndirect, A: f, B: b, C: numVariadic})
+	fn.Body = append(fn.Body, runtime.Instruction{Op: runtime.OpCallIndirect, A: f, C: numVariadic})
 	fn.Body = append(fn.Body, runtime.Instruction{Op: runtime.Operation(shift[0]), A: shift[1], B: shift[2], C: shift[3]})
 }
 

--- a/compiler/checker_dependencies.go
+++ b/compiler/checker_dependencies.go
@@ -354,12 +354,6 @@ func nodeDeps(n ast.Node, scopes depScopes) []*ast.Identifier {
 		return append(deps, nodeDeps(n.Value, scopes)...)
 	case *ast.Show:
 		return nodeDeps(n.Expr, scopes)
-	case *ast.ShowMacro:
-		deps := nodeDeps(n.Macro, scopes)
-		for _, arg := range n.Args {
-			deps = append(deps, nodeDeps(arg, scopes)...)
-		}
-		return deps
 	case *ast.SliceType:
 		return nodeDeps(n.ElementType, scopes)
 	case *ast.Slicing:

--- a/compiler/checker_statements.go
+++ b/compiler/checker_statements.go
@@ -651,10 +651,6 @@ nodesLoop:
 			ti.setValue(nil)
 			tc.terminating = false
 
-		case *ast.ShowMacro:
-			nodes[i] = ast.NewCall(node.Pos(), node.Macro, node.Args, node.IsVariadic)
-			continue nodesLoop // check nodes[i]
-
 		case *ast.Defer:
 			if node.Call.Parenthesis() > 0 {
 				panic(tc.errorf(node.Call, "expression in defer must not be parenthesized"))

--- a/compiler/checker_template_test.go
+++ b/compiler/checker_template_test.go
@@ -57,7 +57,7 @@ var templateCases = []struct {
 
 	// Show macro.
 	{
-		src:      `{% macro M %}{% end %}         {% show M %}`,
+		src:      `{% macro M %}{% end %}         {% show M() %}`,
 		expected: ok,
 	},
 	{
@@ -75,7 +75,7 @@ var templateCases = []struct {
 	},
 
 	{
-		src:      `{% show M %}`,
+		src:      `{% show M() %}`,
 		expected: `undefined: M`,
 	},
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -386,7 +386,7 @@ func emitTemplate(tree *ast.Tree, typeInfos map[ast.Node]*typeInfo, indirectVars
 			// package variables.
 			var initVarsIndex int8 = 0
 			e.fb.fn.Functions = append(e.fb.fn.Functions, nil)
-			e.fb.emitCall(initVarsIndex, e.fb.currentStackShift(), nil, false)
+			e.fb.emitCallFunc(initVarsIndex, e.fb.currentStackShift(), nil)
 			e.emitNodes(extends.Tree.Nodes)
 			e.fb.end()
 			e.fb.exitScope()

--- a/compiler/disassembler.go
+++ b/compiler/disassembler.go
@@ -279,7 +279,8 @@ func disassembleFunction(b *bytes.Buffer, globals []Global, fn *runtime.Function
 			b.WriteByte('\n')
 		}
 		switch in.Op {
-		case runtime.OpCall, runtime.OpCallIndirect, runtime.OpCallPredefined, runtime.OpTailCall, runtime.OpSlice, runtime.OpStringSlice:
+		case runtime.OpCallFunc, runtime.OpCallMacro, runtime.OpCallIndirect, runtime.OpCallPredefined,
+			runtime.OpTailCall, runtime.OpSlice, runtime.OpStringSlice:
 			addr += 1
 		case runtime.OpDefer:
 			addr += 2
@@ -363,10 +364,10 @@ func disassembleInstruction(fn *runtime.Function, globals []Global, addr runtime
 		s += " " + disassembleOperand(fn, c, kind, false)
 	case runtime.OpBreak, runtime.OpContinue, runtime.OpGoto:
 		s += " " + strconv.Itoa(int(decodeUint24(a, b, c)))
-	case runtime.OpCall, runtime.OpCallIndirect, runtime.OpCallPredefined, runtime.OpTailCall, runtime.OpDefer:
+	case runtime.OpCallFunc, runtime.OpCallMacro, runtime.OpCallIndirect, runtime.OpCallPredefined, runtime.OpTailCall, runtime.OpDefer:
 		if a != runtime.CurrentFunction {
 			switch op {
-			case runtime.OpCall, runtime.OpTailCall:
+			case runtime.OpCallFunc, runtime.OpCallMacro, runtime.OpTailCall:
 				sf := fn.Functions[uint8(a)]
 				s += " " + packageName(sf.Pkg) + "." + sf.Name
 			case runtime.OpCallIndirect:
@@ -711,7 +712,7 @@ func disassembleInstruction(fn *runtime.Function, globals []Global, addr runtime
 // index and addr is meaningful, depending on the operation specified by op.
 func funcNameType(fn *runtime.Function, index int8, addr runtime.Addr, op runtime.Operation) (bool, string, reflect.Type) {
 	switch op {
-	case runtime.OpCall:
+	case runtime.OpCallFunc, runtime.OpCallMacro:
 		macro := fn.Functions[index].Macro
 		typ := fn.Functions[index].Type
 		name := fn.Functions[index].Name
@@ -958,10 +959,9 @@ var operationName = [...]string{
 
 	runtime.OpBreak: "Break",
 
-	runtime.OpCall: "Call",
-
-	runtime.OpCallIndirect: "Call",
-
+	runtime.OpCallFunc:       "Call",
+	runtime.OpCallIndirect:   "Call",
+	runtime.OpCallMacro:      "Call",
 	runtime.OpCallPredefined: "Call",
 
 	runtime.OpCap: "Cap",

--- a/compiler/emitter_assignment.go
+++ b/compiler/emitter_assignment.go
@@ -343,7 +343,7 @@ func (em *emitter) assignValuesToAddresses(addresses []address, values []ast.Exp
 	switch valueExpr := values[0].(type) {
 
 	case *ast.Call:
-		regs, retTypes := em.emitCallNode(valueExpr, false, false)
+		regs, retTypes := em.emitCallNode(valueExpr, false, false, runtime.SameFormat)
 		for i, addr := range addresses {
 			addr.assign(false, regs[i], retTypes[i])
 		}

--- a/compiler/emitter_expressions.go
+++ b/compiler/emitter_expressions.go
@@ -135,7 +135,7 @@ func (em *emitter) _emitExpr(expr ast.Expression, dstType reflect.Type, reg int8
 
 		// Function call.
 		em.fb.enterStack()
-		regs, types := em.emitCallNode(expr, false, false)
+		regs, types := em.emitCallNode(expr, false, false, runtime.SameFormat)
 		if reg != 0 {
 			em.changeRegister(false, regs[0], reg, types[0], dstType)
 		}
@@ -194,7 +194,7 @@ func (em *emitter) _emitExpr(expr ast.Expression, dstType reflect.Type, reg int8
 			// Macro declarations are handled as function declarations at
 			// package level, so the parameter 'closureVar' is always nil for
 			// macros.
-			// In fact this works because macros are called using the 'OpCall'
+			// In fact this works because macros are called using the 'OpCallMacro'
 			// instruction (which sets vm.vars from the global vars) while the
 			// emission of function literals needs the parameter 'closureVar'
 			// because vm.vars is set from the vars stored in the function by

--- a/compiler/parser_test.go
+++ b/compiler/parser_test.go
@@ -1207,19 +1207,19 @@ var treeTests = []struct {
 	{"{% a %= 1 %}", ast.NewTree("", []ast.Node{
 		ast.NewAssignment(p(1, 4, 3, 8), []ast.Expression{ast.NewIdentifier(p(1, 4, 3, 3), "a")},
 			ast.AssignmentModulo, []ast.Expression{ast.NewBasicLiteral(p(1, 9, 8, 8), ast.IntLiteral, "1")})}, ast.FormatHTML)},
-	{"{% show a %}", ast.NewTree("", []ast.Node{
-		ast.NewShowMacro(p(1, 4, 3, 8), ast.NewIdentifier(p(1, 9, 8, 8), "a"), nil, false, ast.ContextHTML)}, ast.FormatHTML)},
+	{"{% show a %}", ast.NewTree("", []ast.Node{ast.NewShow(p(1, 4, 3, 8), ast.NewIdentifier(p(1, 9, 8, 8), "a"), ast.ContextHTML)}, ast.FormatHTML)},
 	{"{% show a(b,c) %}", ast.NewTree("", []ast.Node{
-		ast.NewShowMacro(p(1, 4, 3, 13), ast.NewIdentifier(p(1, 9, 8, 8), "a"), []ast.Expression{
-			ast.NewIdentifier(p(1, 11, 10, 10), "b"), ast.NewIdentifier(p(1, 13, 12, 12), "c")}, false, ast.ContextHTML)}, ast.FormatHTML)},
-	{"{% show a(b,c...) %}", ast.NewTree("", []ast.Node{
-		ast.NewShowMacro(p(1, 4, 3, 16), ast.NewIdentifier(p(1, 9, 8, 8), "a"), []ast.Expression{
-			ast.NewIdentifier(p(1, 11, 10, 10), "b"), ast.NewIdentifier(p(1, 13, 12, 12), "c")}, true, ast.ContextHTML)}, ast.FormatHTML)},
-	{"{% show(a) %}", ast.NewTree("", []ast.Node{ast.NewShow(p(1, 4, 3, 9), ast.NewIdentifier(p(1, 9, 8, 8), "a"), ast.ContextHTML)}, ast.FormatHTML)},
-	{"<script>{% show(a) %}</script>", ast.NewTree("", []ast.Node{
+		ast.NewShow(p(1, 4, 3, 13),
+			ast.NewCall(p(1, 10, 8, 13),
+				ast.NewIdentifier(p(1, 9, 8, 8), "a"),
+				[]ast.Expression{ast.NewIdentifier(p(1, 11, 10, 10), "b"), ast.NewIdentifier(p(1, 13, 12, 12), "c")},
+				false),
+			ast.ContextHTML),
+	}, ast.FormatHTML)},
+	{"<script>{% show a %}</script>", ast.NewTree("", []ast.Node{
 		ast.NewText(p(1, 1, 0, 7), []byte("<script>"), ast.Cut{}),
-		ast.NewShow(p(1, 12, 11, 17), ast.NewIdentifier(p(1, 17, 16, 16), "a"), ast.ContextJS),
-		ast.NewText(p(1, 22, 21, 29), []byte("</script>"), ast.Cut{}),
+		ast.NewShow(p(1, 12, 11, 16), ast.NewIdentifier(p(1, 17, 16, 16), "a"), ast.ContextJS),
+		ast.NewText(p(1, 21, 20, 28), []byte("</script>"), ast.Cut{}),
 	}, ast.FormatHTML)},
 	{"{% for v in e %}b{% end for %}", ast.NewTree("", []ast.Node{
 		ast.NewForRange(p(1, 4, 3, 26), ast.NewAssignment(p(1, 8, 7, 12), []ast.Expression{
@@ -2439,34 +2439,6 @@ func equals(n1, n2 ast.Node, p int) error {
 		err = equals(nn1.Type, nn2.Type, p)
 		if err != nil {
 			return err
-		}
-
-	case *ast.ShowMacro:
-		nn2, ok := n2.(*ast.ShowMacro)
-		if !ok {
-			return fmt.Errorf("unexpected %#v, expecting %#v", n1, n2)
-		}
-		err := equals(nn1.Macro, nn2.Macro, p)
-		if err != nil {
-			return err
-		}
-		if len(nn1.Args) != len(nn2.Args) {
-			return fmt.Errorf("unexpected arguments len %d, expecting %d", len(nn1.Args), len(nn2.Args))
-		}
-		for i, node := range nn1.Args {
-			err := equals(node, nn2.Args[i], p)
-			if err != nil {
-				return err
-			}
-		}
-		if nn1.IsVariadic && !nn2.IsVariadic {
-			return fmt.Errorf("unexpected not variadic, expecting variadic")
-		}
-		if !nn1.IsVariadic && nn2.IsVariadic {
-			return fmt.Errorf("unexpected variadic, expecting not variadic")
-		}
-		if nn1.Context != nn2.Context {
-			return fmt.Errorf("unexpected context %s, expecting %s", nn1.Context, nn2.Context)
 		}
 
 	case *ast.Return:

--- a/runtime/env.go
+++ b/runtime/env.go
@@ -70,11 +70,12 @@ type Types interface {
 }
 
 type Renderer interface {
-	Enter(out io.Writer, fromFormat, toFormat uint8) Renderer
-	Exit() error
 	Show(env Env, v interface{}, ctx uint8)
 	Text(env Env, txt []byte, ctx uint8)
 	Out() io.Writer
+	WithOut(out io.Writer) Renderer
+	WithConversion(fromFormat, toFormat uint8) Renderer
+	Close() error
 }
 
 // The env type implements the Env interface.

--- a/templates/full_template_test/layouts/home.html
+++ b/templates/full_template_test/layouts/home.html
@@ -9,7 +9,7 @@
   {# metaTags #}
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="initial-scale=1.0, width=device-width, user-scalable=no">
-  {% show Head %}
+  {% show Head() %}
 </head>
 <body>
 
@@ -22,7 +22,7 @@
 {% show Banner(0, true, "6000/500") %}
 
 <div class="main" role="main">
-    {% show Main %}
+    {% show Main() %}
 </div>
 
 </div>

--- a/templates/full_template_test/layouts/standard.html
+++ b/templates/full_template_test/layouts/standard.html
@@ -2,7 +2,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="initial-scale=1.0, width=device-width, user-scalable=no">
-  {% show Head %}
+  {% show Head() %}
 </head>
 <body>
 
@@ -13,7 +13,7 @@
 {% partial "/partials/navigation.html" %}
 
 <div class="main" role="main">
-    {% show Main %}
+    {% show Main() %}
 </div>
 
 </div>

--- a/templates/renderer_build.go
+++ b/templates/renderer_build.go
@@ -54,9 +54,9 @@ func decodeRenderContext(c uint8) (ast.Context, bool, bool) {
 // during the build of the template to type checks a show statement.
 type buildRenderer struct{}
 
-func (r buildRenderer) Enter(io.Writer, uint8, uint8) runtime.Renderer { return nil }
+func (r buildRenderer) Close() error { return nil }
 
-func (r buildRenderer) Exit() error { return nil }
+func (r buildRenderer) Out() io.Writer { return nil }
 
 func (r buildRenderer) Show(env runtime.Env, v interface{}, context uint8) {
 	t := env.Types().TypeOf(v)
@@ -134,10 +134,9 @@ func (r buildRenderer) Show(env runtime.Env, v interface{}, context uint8) {
 
 func (r buildRenderer) Text(runtime.Env, []byte, uint8) {}
 
-// Out returns the out writer.
-func (r buildRenderer) Out() io.Writer {
-	return nil
-}
+func (r buildRenderer) WithConversion(uint8, uint8) runtime.Renderer { return nil }
+
+func (r buildRenderer) WithOut(io.Writer) runtime.Renderer { return nil }
 
 // shownAsJS reports whether a type can be shown as JavaScript. It returns
 // an error if the type cannot be shown.

--- a/templates/template_test.go
+++ b/templates/template_test.go
@@ -943,7 +943,7 @@ var templateMultiPageCases = map[string]struct {
 
 	"Macro definition (no arguments) and show-macro": {
 		sources: map[string]string{
-			"index.txt": `{% macro M %}body{% end %}{% show M %}`,
+			"index.txt": `{% macro M %}body{% end %}{% show M() %}`,
 		},
 		expectedOut: `body`,
 	},
@@ -990,7 +990,7 @@ var templateMultiPageCases = map[string]struct {
 
 	"Two macro definitions and three show-macro": {
 		sources: map[string]string{
-			"index.txt": `{% macro M1 %}M1's body{% end %}{% macro M2(i int, s string) %}i: {{ i }}, s: {{ s }}{% end %}Show macro: {% show M1 %} {% show M2(-30, "hello") %} ... {% show M1 %}`,
+			"index.txt": `{% macro M1 %}M1's body{% end %}{% macro M2(i int, s string) %}i: {{ i }}, s: {{ s }}{% end %}Show macro: {% show M1() %} {% show M2(-30, "hello") %} ... {% show M1() %}`,
 		},
 		expectedOut: `Show macro: M1's body i: -30, s: hello ... M1's body`,
 	},
@@ -1004,7 +1004,7 @@ var templateMultiPageCases = map[string]struct {
 
 	"Macro definition and show-macro without parentheses": {
 		sources: map[string]string{
-			"index.txt": `{% macro M %}ok{% end %}{% show M %}`,
+			"index.txt": `{% macro M %}ok{% end %}{% show M() %}`,
 		},
 		expectedOut: `ok`,
 	},
@@ -1072,7 +1072,7 @@ var templateMultiPageCases = map[string]struct {
 
 	"Import/Macro - Importing a macro defined in another page": {
 		sources: map[string]string{
-			"index.txt": `{% import "/page.txt" %}{% show M %}{% show M %}`,
+			"index.txt": `{% import "/page.txt" %}{% show M() %}{% show M() %}`,
 			"page.txt":  `{% macro M %}macro!{% end %}{% macro M2 %}macro 2!{% end %}`,
 		},
 		expectedOut: "macro!macro!",
@@ -1080,10 +1080,10 @@ var templateMultiPageCases = map[string]struct {
 
 	"Import/Macro - Importing a macro defined in another page, where a function calls a before-declared function": {
 		sources: map[string]string{
-			"index.txt": `{% import "/page.txt" %}{% show M %}{% show M %}`,
+			"index.txt": `{% import "/page.txt" %}{% show M() %}{% show M() %}`,
 			"page.txt": `
 				{% macro M2 %}macro 2!{% end %}
-				{% macro M %}{% show M2 %}{% end %}
+				{% macro M %}{% show M2() %}{% end %}
 			`,
 		},
 		expectedOut: "macro 2!macro 2!",
@@ -1091,9 +1091,9 @@ var templateMultiPageCases = map[string]struct {
 
 	"Import/Macro - Importing a macro defined in another page, where a function calls an after-declared function": {
 		sources: map[string]string{
-			"index.txt": `{% import "/page.txt" %}{% show M %}{% show M %}`,
+			"index.txt": `{% import "/page.txt" %}{% show M() %}{% show M() %}`,
 			"page.txt": `
-				{% macro M %}{% show M2 %}{% end %}
+				{% macro M %}{% show M2() %}{% end %}
 				{% macro M2 %}macro 2!{% end %}
 			`,
 		},
@@ -1102,8 +1102,8 @@ var templateMultiPageCases = map[string]struct {
 
 	"Import/Macro - Importing a macro defined in another page, which imports a third page": {
 		sources: map[string]string{
-			"index.txt": `{% import "/page1.txt" %}index-start,{% show M1 %}index-end`,
-			"page1.txt": `{% import "/page2.txt" %}{% macro M1 %}M1-start,{% show M2 %}M1-end,{% end %}`,
+			"index.txt": `{% import "/page1.txt" %}index-start,{% show M1() %}index-end`,
+			"page1.txt": `{% import "/page2.txt" %}{% macro M1 %}M1-start,{% show M2() %}M1-end,{% end %}`,
 			"page2.txt": `{% macro M2 %}M2,{% end %}`,
 		},
 		expectedOut: "index-start,M1-start,M2,M1-end,index-end",
@@ -1111,7 +1111,7 @@ var templateMultiPageCases = map[string]struct {
 
 	"Import/Macro - Importing a macro using an import statement with identifier": {
 		sources: map[string]string{
-			"index.txt": `{% import pg "/page.txt" %}{% show pg.M %}{% show pg.M %}`,
+			"index.txt": `{% import pg "/page.txt" %}{% show pg.M() %}{% show pg.M() %}`,
 			"page.txt":  `{% macro M %}macro!{% end %}`,
 		},
 		expectedOut: "macro!macro!",
@@ -1119,7 +1119,7 @@ var templateMultiPageCases = map[string]struct {
 
 	"Import/Macro - Importing a macro using an import statement with identifier (with comments)": {
 		sources: map[string]string{
-			"index.txt": `{# a comment #}{% import pg "/page.txt" %}{# a comment #}{% show pg.M %}{# a comment #}{% show pg.M %}{# a comment #}`,
+			"index.txt": `{# a comment #}{% import pg "/page.txt" %}{# a comment #}{% show pg.M() %}{# a comment #}{% show pg.M() %}{# a comment #}`,
 			"page.txt":  `{# a comment #}{% macro M %}{# a comment #}macro!{# a comment #}{% end %}{# a comment #}`,
 		},
 		expectedOut: "macro!macro!",
@@ -1136,7 +1136,7 @@ var templateMultiPageCases = map[string]struct {
 	"Extends - Extending a page that calls a macro defined on current page": {
 		sources: map[string]string{
 			"index.txt": `{% extends "/page.txt" %}{% macro E %}E's body{% end %}`,
-			"page.txt":  `{% show E %}`,
+			"page.txt":  `{% show E() %}`,
 		},
 		expectedOut: "E's body",
 	},
@@ -1167,7 +1167,7 @@ var templateMultiPageCases = map[string]struct {
 	"Extends - Extending a page that calls two macros defined on current page": {
 		sources: map[string]string{
 			"index.txt": `{% extends "/page.txt" %}{% macro E1 %}E1's body{% end %}{% macro E2 %}E2's body{% end %}`,
-			"page.txt":  `{% show E1 %}{% show E2 %}`,
+			"page.txt":  `{% show E1() %}{% show E2() %}`,
 		},
 		expectedOut: "E1's bodyE2's body",
 	},
@@ -1175,7 +1175,7 @@ var templateMultiPageCases = map[string]struct {
 	"Extends - Define a variable (with zero value) used in macro definition": {
 		sources: map[string]string{
 			"index.txt": `{% extends "/page.txt" %}{% var Local int %}{% macro E1 %}Local has value {{ Local }}{% end %}`,
-			"page.txt":  `{% show E1 %}`,
+			"page.txt":  `{% show E1() %}`,
 		},
 		expectedOut: "Local has value 0",
 	},
@@ -1183,7 +1183,7 @@ var templateMultiPageCases = map[string]struct {
 	"Extends - Define a variable (with non-zero value) used in macro definition": {
 		sources: map[string]string{
 			"index.txt": `{% extends "/page.txt" %}{% var Local = 50 %}{% macro E1 %}Local has value {{ Local }}{% end %}`,
-			"page.txt":  `{% show E1 %}`,
+			"page.txt":  `{% show E1() %}`,
 		},
 		expectedOut: "Local has value 50",
 	},
@@ -1435,7 +1435,7 @@ var templateMultiPageCases = map[string]struct {
 
 	"A partial file defines a macro, which should not be accessible from the file that renders the partial": {
 		sources: map[string]string{
-			"index.txt":   `{% partial "partial.txt" %}{% show MacroInPartialFile %}`,
+			"index.txt":   `{% partial "partial.txt" %}{% show MacroInPartialFile() %}`,
 			"partial.txt": `{% macro MacroInPartialFile %}{% end macro %}`,
 		},
 		expectedBuildErr: "undefined: MacroInPartialFile",
@@ -1444,7 +1444,7 @@ var templateMultiPageCases = map[string]struct {
 	"The file with a partial defines a macro, which should not be accessible from the partial file": {
 		sources: map[string]string{
 			"index.txt":   `{% macro Macro %}{% end macro %}{% partial "partial.txt" %}`,
-			"partial.txt": `{% show Macro %}`,
+			"partial.txt": `{% show Macro() %}`,
 		},
 		expectedBuildErr: "undefined: Macro",
 	},
@@ -1488,7 +1488,7 @@ var templateMultiPageCases = map[string]struct {
 	"Using the precompiled package 'fmt' from a file that extends another file": {
 		sources: map[string]string{
 			"index.txt":    `{% extends "extended.txt" %}{% import "fmt" %}{% macro M %}{{ fmt.Sprint(321, 11) }}{% end macro %}`,
-			"extended.txt": `{% show M %}`,
+			"extended.txt": `{% show M() %}`,
 		},
 		packages:    testPackages,
 		expectedOut: "321 11",
@@ -1588,7 +1588,7 @@ var templateMultiPageCases = map[string]struct {
 	// https://github.com/open2b/scriggo/issues/642
 	"Macro imported twice - test compilation": {
 		sources: map[string]string{
-			"index.html":    `{% import "/imported.html" %}{% import "/macro.html" %}{% show M %}`,
+			"index.html":    `{% import "/imported.html" %}{% import "/macro.html" %}{% show M() %}`,
 			"imported.html": `{% import "/macro.html" %}`,
 			"macro.html":    `{% macro M %}{% end macro %}`,
 		},
@@ -1713,7 +1713,7 @@ var templateMultiPageCases = map[string]struct {
 
 	"Accessing global variable from macro's body": {
 		sources: map[string]string{
-			"index.txt": `{% macro M %}{{ globalVariable }}{% end %}{% show M %}`,
+			"index.txt": `{% macro M %}{{ globalVariable }}{% end %}{% show M() %}`,
 		},
 		main: scriggo.MapPackage{
 			PkgName: "main",
@@ -1790,10 +1790,10 @@ var templateMultiPageCases = map[string]struct {
 				{% macro M1 %}
 					{% if true %}
 						{% macro M2 %}m2{% end macro %}
-						{% show M2 %}
+						{% show M2() %}
 					{% end %}
 				{% end macro %}
-				{% show M1 %}
+				{% show M1() %}
 			`,
 		},
 		expectedOut: "\n\t\t\t\t\t\t\t\t\t\t\n\t\t\t\t\t\tm2\n\n\t\t\t",
@@ -2210,7 +2210,7 @@ var templateMultiPageCases = map[string]struct {
 	"Multiline statements #5": {
 		sources: map[string]string{
 			"index.txt":    `{%% extends "extended.txt" %%}{% import "fmt" %}{% macro M %}{{ fmt.Sprint(321, 11) }}{% end macro %}`,
-			"extended.txt": `{% show M %}`,
+			"extended.txt": `{% show M() %}`,
 		},
 		packages:    testPackages,
 		expectedOut: "321 11",
@@ -2285,7 +2285,7 @@ var templateMultiPageCases = map[string]struct {
 	"Endless macro declaration": {
 		sources: map[string]string{
 			"index.html":  `{% extends "layout.html" %}{% Article %}content`,
-			"layout.html": `{% show Article %}`,
+			"layout.html": `{% show Article() %}`,
 		},
 		expectedOut: `content`,
 	},
@@ -2293,7 +2293,7 @@ var templateMultiPageCases = map[string]struct {
 	"Endless macro declaration (2)": {
 		sources: map[string]string{
 			"index.html":  `{% extends "layout.html" %}{% Article %}{% Content %}`,
-			"layout.html": `{% show Article %}`,
+			"layout.html": `{% show Article() %}`,
 		},
 		expectedBuildErr: `undefined: Content`,
 	},
@@ -2301,7 +2301,7 @@ var templateMultiPageCases = map[string]struct {
 	"Endless macro declaration (3)": {
 		sources: map[string]string{
 			"index.html":  `{% extends "layout.html" %}{% Article %}{% end macro %}`,
-			"layout.html": `{% show Article %}`,
+			"layout.html": `{% show Article() %}`,
 		},
 		expectedBuildErr: `syntax error: unexpected end`,
 	},
@@ -2309,14 +2309,14 @@ var templateMultiPageCases = map[string]struct {
 	"Endless macro declaration (4)": {
 		sources: map[string]string{
 			"index.html":  `{% extends "layout.html" %}{% article %}{% end %}`,
-			"layout.html": `{% show Article %}`,
+			"layout.html": `{% show Article() %}`,
 		},
 		expectedBuildErr: `syntax error: unexpected article, expecting declaration statement`,
 	},
 
 	"Endless macro declaration (5)": {
 		sources: map[string]string{
-			"index.html":    `{% import "imported.html" %}{% show Article %}`,
+			"index.html":    `{% import "imported.html" %}{% show Article() %}`,
 			"imported.html": `{% Article %}`,
 		},
 		expectedBuildErr: `syntax error: unexpected Article, expecting declaration statement`,
@@ -2360,7 +2360,7 @@ var templateMultiPageCases = map[string]struct {
 
 	"Macro used in function call - a non-empty string is returned (2)": {
 		sources: map[string]string{
-			"index.html": `{% macro M %}hello{% end %}{% var str = M() %}len(str): {{ len(str) }}, output of macro: {% M() %}`,
+			"index.html": `{% macro M %}hello{% end %}{% var str = M() %}len(str): {{ len(str) }}, output of macro: {{ M() }}`,
 		},
 		expectedOut: `len(str): 5, output of macro: hello`,
 	},
@@ -2576,7 +2576,7 @@ var envFilePathCases = []struct {
 	{
 		name: "File importing another file, which defines a macro",
 		sources: map[string]string{
-			"index.html":    `{% import "imported.html" %}{{ path() }}, {% show Path %}, {{ path() }}`,
+			"index.html":    `{% import "imported.html" %}{{ path() }}, {% show Path() %}, {{ path() }}`,
 			"imported.html": `{% macro Path %}{{ path() }}{% end %}`,
 		},
 		want: `index.html, imported.html, index.html`,
@@ -2586,7 +2586,7 @@ var envFilePathCases = []struct {
 		name: "File extending another file",
 		sources: map[string]string{
 			"index.html":    `{% extends "extended.html" %}{% macro Path %}{{ path() }}{% end %}`,
-			"extended.html": `{{ path() }}, {% show Path %}`,
+			"extended.html": `{{ path() }}, {% show Path() %}`,
 		},
 		want: `extended.html, index.html`,
 	},

--- a/test/compare/testdata/templates/endless.dir/layout.html
+++ b/test/compare/testdata/templates/endless.dir/layout.html
@@ -1,1 +1,1 @@
-{% show Article %}
+{% show Article() %}

--- a/test/compare/testdata/templates/extends.dir/layouts/home.html
+++ b/test/compare/testdata/templates/extends.dir/layouts/home.html
@@ -1,5 +1,5 @@
 Extended
 
-<head>{% show Head %}</head>
+<head>{% show Head() %}</head>
 
-{% show Main %}
+{% show Main() %}

--- a/test/compare/testdata/templates/extends_raw_strings.dir/layouts/home.html
+++ b/test/compare/testdata/templates/extends_raw_strings.dir/layouts/home.html
@@ -1,5 +1,5 @@
 Extended
 
-<head>{% show Head %}</head>
+<head>{% show Head() %}</head>
 
-{% show Main %}
+{% show Main() %}

--- a/test/compare/testdata/templates/macro.html
+++ b/test/compare/testdata/templates/macro.html
@@ -6,6 +6,6 @@
 
 {% macro M3(a string) %}called M3 with argument '{{ a }}'{% end macro %}
 
-{% show M1 %}
+{% show M1() %}
 {% show M2(20, 20) %}
 {% show M3("a string!") %}

--- a/test/compare/testdata/templates/main_functions_import.dir/index.html
+++ b/test/compare/testdata/templates/main_functions_import.dir/index.html
@@ -1,4 +1,4 @@
 {% import "imported.html" %}
 Access from 'index.html': {{ MainSum(10, 20) }}
 {% partial "partial.html" %}
-{% show Imported %}
+{% show Imported() %}

--- a/test/compare/testdata/templates/markdown-in-html.dir/imports.md
+++ b/test/compare/testdata/templates/markdown-in-html.dir/imports.md
@@ -1,6 +1,6 @@
 
 {% macro B(items []string) %}
-{% show b %}
+{% show b() %}
 {% for item in items %}
 * {{ item }}
 {% end %}

--- a/test/compare/testdata/templates/markdown-in-html.dir/layout.html
+++ b/test/compare/testdata/templates/markdown-in-html.dir/layout.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 
-{% show A %}
+{% show A() %}
 
 {% show B([]string{"item 1", "item 2", "item 3"}) %}
 

--- a/test/compare/testdata/templates/show.html
+++ b/test/compare/testdata/templates/show.html
@@ -4,7 +4,7 @@
 {% show _ %}   // ERROR `cannot use _ as value`
 {% show(_) %}  // ERROR `cannot use _ as value`
 
-{% show %}     // ERROR `syntax error: unexpected %}, expecting identifier, string or (`
+{% show %}     // ERROR `syntax error: unexpected %}, expecting expression`
 {% show() %}   // ERROR `syntax error: unexpected ), expecting expression`
 {% partial "" %}  // ERROR `syntax error: invalid template path: ""`
 

--- a/test/compare/testdata/templates/statements2.html
+++ b/test/compare/testdata/templates/statements2.html
@@ -22,7 +22,7 @@ d = {{ d }}
 e = {{ e }}
 
 {% macro A %}A{% end %}
-{%% show A %%}
+{%% show A() %%}
 
 {%%
     if e == 6 {


### PR DESCRIPTION
This change replaces the two statements `show(<expr>)` and `show <macro>` with the statement `show <expr>` with the same behavior as `show(<expr>)`.

It also

- does not allow the `show` statement in functions that are not macro

- fixes the `toFormat` in macro calls to be the format of the call expression and not the  file format

- renames the VM internal `Call` operation to `CallFunc` and adds the internal `CallMacro` operation.

The statement `show <path>` continues to be deprecated and to show a string literal with the `show` statement, the string should be put in parenthesis.

For #698