### PR TITLE
compiler: make 'for in' statement iterate over the keys of a map

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -584,7 +584,22 @@ func NewFor(pos *Position, init Node, condition Expression, post Node, body []No
 	return &For{pos, init, condition, post, body}
 }
 
-// ForRange node represents statements "for range" and "for in".
+// ForIn node represents the "for in" statement.
+type ForIn struct {
+	*Position             // position in the source.
+	Ident     *Identifier // identifier.
+	Expr      Expression  // range expression.
+	Body      []Node      // nodes of the body.
+}
+
+func NewForIn(pos *Position, ident *Identifier, expr Expression, body []Node) *ForIn {
+	if body == nil {
+		body = []Node{}
+	}
+	return &ForIn{pos, ident, expr, body}
+}
+
+// ForRange node represents the "for range" statement.
 type ForRange struct {
 	*Position              // position in the source.
 	Assignment *Assignment // assignment.

--- a/compiler/ast/astutil/clone.go
+++ b/compiler/ast/astutil/clone.go
@@ -113,6 +113,15 @@ func CloneNode(node ast.Node) ast.Node {
 		}
 		return ast.NewFor(ClonePosition(n.Position), init, CloneExpression(n.Condition), post, body)
 
+	case *ast.ForIn:
+		ident := CloneNode(n.Ident).(*ast.Identifier)
+		expr := CloneExpression(n.Expr)
+		var body = make([]ast.Node, len(n.Body))
+		for i, n2 := range n.Body {
+			body[i] = CloneNode(n2)
+		}
+		return ast.NewForIn(ClonePosition(n.Position), ident, expr, body)
+
 	case *ast.ForRange:
 		var body = make([]ast.Node, len(n.Body))
 		for i, n2 := range n.Body {

--- a/compiler/ast/astutil/dump_test.go
+++ b/compiler/ast/astutil/dump_test.go
@@ -73,19 +73,15 @@ func ExampleDump() {
 	// │    │    BasicLiteral (1:12) 10
 	//
 	// Tree: "":1:1
-	// │    ForRange (1:4) 1:4
-	// │    │    Assignment (1:8) _, i := x
-	// │    │    │    Identifier (1:8) _
-	// │    │    │    Identifier (1:8) i
-	// │    │    │    Identifier (1:13) x
+	// │    ForIn (1:4) 1:4
+	// │    │    Identifier (1:8) i
+	// │    │    Identifier (1:13) x
 	// │    │    Text (1:17) " some text, blah blah blah "
 	//
 	// Tree: "":1:1
-	// │    ForRange (1:4) 1:4
-	// │    │    Assignment (1:8) _, i := x
-	// │    │    │    Identifier (1:8) _
-	// │    │    │    Identifier (1:8) i
-	// │    │    │    Identifier (1:13) x
+	// │    ForIn (1:4) 1:4
+	// │    │    Identifier (1:8) i
+	// │    │    Identifier (1:13) x
 	// │    │    Text (1:17) " some very very very very very..."
 	//
 	// Tree: "":1:1

--- a/compiler/ast/astutil/walk.go
+++ b/compiler/ast/astutil/walk.go
@@ -100,11 +100,17 @@ func Walk(v Visitor, node ast.Node) {
 			Walk(v, n)
 		}
 
+	case *ast.ForIn:
+		Walk(v, n.Ident)
+		Walk(v, n.Expr)
+		for _, n := range n.Body {
+			Walk(v, n)
+		}
+
 	case *ast.ForRange:
 		if n.Assignment != nil {
 			Walk(v, n.Assignment)
 		}
-
 		for _, n := range n.Body {
 			Walk(v, n)
 		}

--- a/compiler/ast/astutil/walk_test.go
+++ b/compiler/ast/astutil/walk_test.go
@@ -49,7 +49,7 @@ func TestWalk(t *testing.T) {
 		{`{{ call(3, 5) }}`, []int{0, 0, 3, 8, 11}},
 		{`{% if 5 > 4 %} some text {% end %}`, []int{0, 3, 6, 6, 10, 0, 14}},
 		{`{% if 5 > 4 %} some text {% else %} some text {% end %}`, []int{0, 3, 6, 6, 10, 0, 14, 0, 35}},
-		{`{% for p in ps %} some text {% end %}`, []int{0, 3, 7, 7, 7, 12, 17}},
+		{`{% for p in ps %} some text {% end %}`, []int{0, 3, 7, 12, 17}},
 		{`{% macro Body %} some text {% end %}`, []int{0, 3, 16}},
 		{`{{ (4+5)*6 }}`, []int{0, 0, 3, 3, 4, 6, 9}},
 		{`{% x = vect[3] %}`, []int{0, 3, 3, 7, 7, 12}},

--- a/compiler/checker_dependencies.go
+++ b/compiler/checker_dependencies.go
@@ -255,6 +255,16 @@ func nodeDeps(n ast.Node, scopes depScopes) []*ast.Identifier {
 		scopes = exitScope(scopes)
 		scopes = exitScope(scopes)
 		return deps
+	case *ast.ForIn:
+		scopes = enterScope(scopes)
+		deps := nodeDeps(n.Ident, scopes)
+		scopes = enterScope(scopes)
+		for _, node := range n.Body {
+			deps = append(deps, nodeDeps(node, scopes)...)
+		}
+		scopes = exitScope(scopes)
+		scopes = exitScope(scopes)
+		return deps
 	case *ast.ForRange:
 		scopes = enterScope(scopes)
 		deps := nodeDeps(n.Assignment, scopes)

--- a/compiler/checker_template_test.go
+++ b/compiler/checker_template_test.go
@@ -512,7 +512,7 @@ var checkerTemplateStmts = []struct {
 	{src: `{%% for v in "abc" { var _ rune = v } %%}`, expected: ok},
 	{src: `{%% for _ in "abc" { } %%}`, expected: ok},
 	{src: `{%% for v in ([...]int{}) { var _ int = v } %%}`, expected: ok},
-	{src: `{%% for v in map[float64]string{} { var _ string = v } %%}`, expected: ok},
+	{src: `{%% for k in map[float64]string{} { var _ float64 = k } %%}`, expected: ok},
 	{src: `{%% for _ in (&[...]int{}) { } %%}`, expected: ok},
 	//{src: `{%% for a in make(<-chan string) { var _ string = a } %%}`, expected: ok}, // TODO(marco): fails with 'too many variables in range'
 	{src: `{%% for _ in 0 { } %%}`, expected: `cannot range over 0 (type untyped number)`},

--- a/compiler/parser.go
+++ b/compiler/parser.go
@@ -607,7 +607,7 @@ LABEL:
 			if init == nil {
 				panic(syntaxError(tok.pos, "unexpected in, expecting expression"))
 			}
-			ident, ok := init.(ast.Expression)
+			ident, ok := init.(*ast.Identifier)
 			if !ok {
 				panic(syntaxError(tok.pos, "unexpected in, expecting {"))
 			}
@@ -616,12 +616,7 @@ LABEL:
 			if expr == nil {
 				panic(syntaxError(tok.pos, "unexpected %s, expecting expression", tok))
 			}
-			ipos := ident.Pos()
-			blank := ast.NewIdentifier(ipos.WithEnd(ipos.Start), "_")
-			aPos := ipos.WithEnd(expr.Pos().End)
-			assignment := ast.NewAssignment(aPos, []ast.Expression{blank, ident}, ast.AssignmentDeclaration, []ast.Expression{expr})
-			assignment.End = expr.Pos().End
-			node = ast.NewForRange(pos, assignment, nil)
+			node = ast.NewForIn(pos, ident, expr, nil)
 		default:
 			panic(syntaxError(tok.pos, "unexpected %s, expecting expression", tok))
 		}
@@ -1696,6 +1691,8 @@ func (p *parsing) addChild(child ast.Node) {
 	case *ast.URL:
 		n.Value = append(n.Value, child)
 	case *ast.For:
+		n.Body = append(n.Body, child)
+	case *ast.ForIn:
 		n.Body = append(n.Body, child)
 	case *ast.ForRange:
 		n.Body = append(n.Body, child)

--- a/test/compare/testdata/templates/statements.golden
+++ b/test/compare/testdata/templates/statements.golden
@@ -5,6 +5,7 @@ count is > 50
 is an int
 res is 474
 123
+123
 5
 -42
 scriggo

--- a/test/compare/testdata/templates/statements.html
+++ b/test/compare/testdata/templates/statements.html
@@ -13,6 +13,7 @@ is an int
 {% res := i.(int) - i2.(int) %}
 res is {{ res }}
 {% for i in []int{1,2,3} %}{{ i }}{% end %}
+{% for k in map[int]string{1:"a",2:"b",3:"c"} %}{{ k }}{% end %}
 {% show(5) %}
 {% show ( i2 ) %}
 {% show("scriggo") %}


### PR DESCRIPTION
This change makes the 'for in' statement iterates over the keys, instead
of the values of a map.

Resolve #696