### PR TITLE
template/builtin: add builtins to operate on time values

### DIFF
--- a/cmd/scriggo/serve.go
+++ b/cmd/scriggo/serve.go
@@ -281,12 +281,21 @@ func (t *templateFS) watch(name string) error {
 }
 
 var globals = templates.Declarations{
+	"Duration":      reflect.TypeOf((*builtin.Duration)(nil)).Elem(),
+	"Hour":          time.Hour,
+	"Microsecond":   time.Microsecond,
+	"Millisecond":   time.Millisecond,
+	"Minute":        time.Minute,
+	"Nanosecond":    time.Nanosecond,
 	"Regexp":        reflect.TypeOf((*builtin.Regexp)(nil)).Elem(),
+	"Second":        time.Second,
+	"Time":          reflect.TypeOf((*builtin.Time)(nil)).Elem(),
 	"abbreviate":    builtin.Abbreviate,
 	"abs":           builtin.Abs,
 	"base64":        builtin.Base64,
 	"capitalize":    builtin.Capitalize,
 	"capitalizeAll": builtin.CapitalizeAll,
+	"date":          builtin.Date,
 	"hasPrefix":     builtin.HasPrefix,
 	"hasSuffix":     builtin.HasSuffix,
 	"hex":           builtin.Hex,
@@ -300,6 +309,9 @@ var globals = templates.Declarations{
 	"max":           builtin.Max,
 	"md5":           builtin.Md5,
 	"min":           builtin.Min,
+	"now":           builtin.Now,
+	"parseDuration": builtin.ParseDuration,
+	"parseTime":     builtin.ParseTime,
 	"queryEscape":   builtin.QueryEscape,
 	"regexp":        builtin.RegExp,
 	"replace":       builtin.Replace,
@@ -323,4 +335,5 @@ var globals = templates.Declarations{
 	"trimPrefix":    builtin.TrimPrefix,
 	"trimRight":     builtin.TrimRight,
 	"trimSuffix":    builtin.TrimSuffix,
+	"unixTime":      builtin.UnixTime,
 }

--- a/cmd/scriggo/sources.go
+++ b/cmd/scriggo/sources.go
@@ -2530,12 +2530,21 @@ func (t *templateFS) watch(name string) error {
 }
 
 var globals = templates.Declarations{
+	"Duration":      reflect.TypeOf((*builtin.Duration)(nil)).Elem(),
+	"Hour":          time.Hour,
+	"Microsecond":   time.Microsecond,
+	"Millisecond":   time.Millisecond,
+	"Minute":        time.Minute,
+	"Nanosecond":    time.Nanosecond,
 	"Regexp":        reflect.TypeOf((*builtin.Regexp)(nil)).Elem(),
+	"Second":        time.Second,
+	"Time":          reflect.TypeOf((*builtin.Time)(nil)).Elem(),
 	"abbreviate":    builtin.Abbreviate,
 	"abs":           builtin.Abs,
 	"base64":        builtin.Base64,
 	"capitalize":    builtin.Capitalize,
 	"capitalizeAll": builtin.CapitalizeAll,
+	"date":          builtin.Date,
 	"hasPrefix":     builtin.HasPrefix,
 	"hasSuffix":     builtin.HasSuffix,
 	"hex":           builtin.Hex,
@@ -2549,6 +2558,9 @@ var globals = templates.Declarations{
 	"max":           builtin.Max,
 	"md5":           builtin.Md5,
 	"min":           builtin.Min,
+	"now":           builtin.Now,
+	"parseDuration": builtin.ParseDuration,
+	"parseTime":     builtin.ParseTime,
 	"queryEscape":   builtin.QueryEscape,
 	"regexp":        builtin.RegExp,
 	"replace":       builtin.Replace,
@@ -2572,6 +2584,7 @@ var globals = templates.Declarations{
 	"trimPrefix":    builtin.TrimPrefix,
 	"trimRight":     builtin.TrimRight,
 	"trimSuffix":    builtin.TrimSuffix,
+	"unixTime":      builtin.UnixTime,
 }
 `)
 	sources["util.go"] = []byte(`// Copyright (c) 2019 Open2b Software Snc. All rights reserved.

--- a/templates/builtin/builtin_test.go
+++ b/templates/builtin/builtin_test.go
@@ -9,6 +9,7 @@ package builtin
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/open2b/scriggo/templates"
 )
@@ -69,6 +70,16 @@ var tests = []struct {
 	{CapitalizeAll(` ab,cd`), " Ab,Cd"},
 	{CapitalizeAll(` Ab,cd`), " Ab,Cd"},
 
+	// date
+	{func() string {
+		t, _ := Date(2009, 11, 10, 12, 15, 32, 680327414, "UTC")
+		return t.Format(time.RFC3339Nano)
+	}(), "2009-11-10T12:15:32.680327414Z"},
+	{func() string {
+		t, _ := Date(2021, 3, 27, 17, 18, 51, 0, "CET")
+		return t.Format(time.RFC3339Nano)
+	}(), "2021-03-27T17:18:51+01:00"},
+
 	// htmlEscape
 	{spf("%s", HtmlEscape(``)), ""},
 	{spf("%s", HtmlEscape(`a`)), "a"},
@@ -118,6 +129,14 @@ var tests = []struct {
 	{spf("%d", Min(7, 5)), "5"},
 	{spf("%d", Min(-7, 5)), "-7"},
 	{spf("%d", Min(7, -5)), "-5"},
+
+	// now
+	{spf("%t", func() bool {
+		t1 := NewTime(time.Now())
+		t := Now()
+		t2 := NewTime(time.Now())
+		return (t.Equal(t1) || t.After(t1)) && (t.Equal(t2) || t.Before(t2))
+	}()), "true"},
 
 	// regexp
 	{spf("%t", RegExp(nil, "(scriggo){2}").Match("scriggo")), "false"},
@@ -183,6 +202,7 @@ var tests = []struct {
 	{func() string { s := []bool{true, false, true}; Sort(s, nil); return spf("%v", s) }(), "[false true true]"},
 	{func() string { s := []templates.HTML{`<b>`, `<a>`, `<c>`}; Sort(s, nil); return spf("%v", s) }(), "[<a> <b> <c>]"},
 
+	// toKebab
 	{ToKebab(""), ""},
 	{ToKebab("AaBbCc"), "aa-bb-cc"},
 	{ToKebab("aBc"), "a-bc"},
@@ -212,6 +232,11 @@ var tests = []struct {
 	{ToKebab("A€€B"), "a-b"},
 	{ToKebab("€€AB"), "ab"},
 	{ToKebab("AB€€"), "ab"},
+
+	// unixTime
+	{UnixTime(0, 0).UTC().Format(time.RFC3339Nano), "1970-01-01T00:00:00Z"},
+	{UnixTime(1616964058, 0).UTC().Format(time.RFC3339Nano), "2021-03-28T20:40:58Z"},
+	{UnixTime(1616964058, 136918407).UTC().Format(time.RFC3339Nano), "2021-03-28T20:40:58.136918407Z"},
 }
 
 func TestBuiltins(t *testing.T) {

--- a/templates/builtin/time.go
+++ b/templates/builtin/time.go
@@ -1,0 +1,282 @@
+// Copyright (c) 2021 Open2b Software Snc. All rights reserved.
+// https://www.open2b.com
+
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package builtin
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/open2b/scriggo/templates"
+)
+
+// A Duration represents the elapsed time between two instants
+// as an int64 nanosecond count. The representation limits the
+// largest representable duration to approximately 290 years.
+type Duration = time.Duration
+
+// A Time represents an instant in time.
+//
+// It is a stripped down version of the Go time.Time type, with additional
+// methods to show time values in JavaScript and JSON contexts.
+type Time struct {
+	t time.Time
+}
+
+// NewTime returns a Time value at the time of t. It is not intended to be
+// used as a builtin but it can be used  to implement builtins that return
+// time values.
+//
+// For example, a builtin that returns the current local time rounded to
+// milliseconds and with location "America/New_York" can be implemented as
+//
+//    func now() builtin.Time {
+//        l := time.LoadLocation("America/New_York")
+//        t := time.Now().Rounded(time.Millisecond).In(l)
+//        return builtin.NewTime(t)
+//    }
+//
+// and once added to the declarations
+//
+//    templates.Declarations{
+//        ...
+//        "now" : now,
+//        ...
+//    }
+//
+// can be used in a template
+//
+//    Current time: {{ now() }}
+//
+func NewTime(t time.Time) Time {
+	return Time{t}
+}
+
+// Add returns the time t+d.
+func (t Time) Add(d Duration) Time {
+	return Time{t.t.Add(d)}
+}
+
+// AddDate returns the time corresponding to adding the given number of years,
+// months and days to t. For example, AddDate(-1, 2, 3) applied to
+// January 1, 2011 returns March 4, 2010.
+//
+// AddDate normalizes its result in the same way that the Date function does.
+func (t Time) AddDate(years, months, days int) Time {
+	return Time{t.t.AddDate(years, months, days)}
+}
+
+// After reports whether the time instant t is after u.
+func (t Time) After(u Time) bool {
+	return t.t.After(u.t)
+}
+
+// Before reports whether the time instant t is before u.
+func (t Time) Before(u Time) bool {
+	return t.t.Before(u.t)
+}
+
+// Clock returns the hour, minute and second within the day specified by t.
+// hour is in the range [0, 23], minute and second are in the range [0, 59].
+func (t Time) Clock() (hour, minute, second int) {
+	return t.t.Clock()
+}
+
+// Date returns the year, month and day in which t occurs. month is in the
+// range [1, 12] and day is in the range [1, 31].
+func (t Time) Date() (year, month, day int) {
+	y, m, d := t.t.Date()
+	return y, int(m), d
+}
+
+// Day returns the day of the month specified by t, in the range [1, 31]
+func (t Time) Day() int {
+	return t.t.Day()
+}
+
+// Equal reports whether t and u represent the same time instant.
+func (t Time) Equal(u Time) bool {
+	return t.t.Equal(u.t)
+}
+
+// Format formats the time value formatted according to layout using the t's
+// formatter.
+func (t Time) Format(layout string) string {
+	return t.t.Format(layout)
+}
+
+// Hour returns the hour within the day specified by t, in the range [0, 23].
+func (t Time) Hour() int {
+	return t.t.Hour()
+}
+
+// JS returns the time as a JavaScript date. The result is undefined if the
+// year of t is not in the range [-999999, 999999].
+func (t Time) JS() templates.JS {
+	y := t.t.Year()
+	ms := int64(t.t.Nanosecond()) / int64(time.Millisecond)
+	name, offset := t.t.Zone()
+	if name == "UTC" {
+		format := `new Date("%0.4d-%0.2d-%0.2dT%0.2d:%0.2d:%0.2d.%0.3dZ")`
+		if y < 0 || y > 9999 {
+			format = `new Date("%+0.6d-%0.2d-%0.2dT%0.2d:%0.2d:%0.2d.%0.3dZ")`
+		}
+		return templates.JS(fmt.Sprintf(format, y, t.t.Month(), t.t.Day(), t.t.Hour(), t.t.Minute(), t.t.Second(), ms))
+	}
+	zone := offset / 60
+	h, m := zone/60, zone%60
+	if m < 0 {
+		m = -m
+	}
+	format := `new Date("%0.4d-%0.2d-%0.2dT%0.2d:%0.2d:%0.2d.%0.3d%+0.2d:%0.2d")`
+	if y < 0 || y > 9999 {
+		format = `new Date("%+0.6d-%0.2d-%0.2dT%0.2d:%0.2d:%0.2d.%0.3d%+0.2d:%0.2d")`
+	}
+	return templates.JS(fmt.Sprintf(format, y, t.t.Month(), t.t.Day(), t.t.Hour(), t.t.Minute(), t.t.Second(), ms, h, m))
+}
+
+// JSON returns a time in a format suitable for use in JSON.
+func (t Time) JSON() templates.JSON {
+	return templates.JSON(`"` + t.t.Format(time.RFC3339) + `"`)
+}
+
+// Month returns the month of the year specified by t, in the range [1, 12]
+// where 1 is January and 12 is December.
+func (t Time) Month() int {
+	return int(t.t.Month())
+}
+
+// Minute returns the minute offset within the hour specified by t, in the
+// range [0, 59].
+func (t Time) Minute() int {
+	return t.t.Minute()
+}
+
+// Nanosecond returns the nanosecond offset within the second specified by t,
+// in the range [0, 999999999].
+func (t Time) Nanosecond() int {
+	return t.t.Nanosecond()
+}
+
+// Round returns the result of rounding t to the nearest multiple of d (since
+// the zero time). The rounding behavior for halfway values is to round up.
+// If d <= 0, Round returns t stripped of any monotonic clock reading but
+// otherwise unchanged.
+//
+// Round operates on the time as an absolute duration since the
+// zero time; it does not operate on the presentation form of the
+// time. Thus, Round(Hour) may return a time with a non-zero
+// minute, depending on the time's Location.
+func (t Time) Round(d Duration) Time {
+	return Time{t.t.Round(d)}
+}
+
+// Second returns the second offset within the minute specified by t, in the
+// range [0, 59].
+func (t Time) Second() int {
+	return t.t.Second()
+}
+
+// String returns the time formatted.
+func (t Time) String() string {
+	return t.t.String()
+}
+
+// Sub returns the duration t-u. If the result exceeds the maximum (or minimum)
+// value that can be stored in a Duration, the maximum (or minimum) duration
+// will be returned.
+// To compute t-d for a duration d, use t.Add(-d).
+func (t Time) Sub(u Time) Duration {
+	return t.t.Sub(u.t)
+}
+
+// Truncate returns the result of rounding t down to a multiple of d (since the zero time).
+// If d <= 0, Truncate returns t stripped of any monotonic clock reading but otherwise unchanged.
+//
+// Truncate operates on the time as an absolute duration since the
+// zero time; it does not operate on the presentation form of the
+// time. Thus, Truncate(Hour) may return a time with a non-zero
+// minute, depending on the time's Location.
+func (t Time) Truncate(d Duration) Time {
+	return Time{t.t.Truncate(d)}
+}
+
+// UTC returns t with the location set to UTC.
+func (t Time) UTC() Time {
+	return Time{t.t.UTC()}
+}
+
+// Unix returns t as a Unix time, the number of seconds elapsed
+// since January 1, 1970 UTC. The result does not depend on the
+// location associated with t.
+// Unix-like operating systems often record time as a 32-bit
+// count of seconds, but since the method here returns a 64-bit
+// value it is valid for billions of years into the past or future.
+func (t Time) Unix() int64 {
+	return t.t.Unix()
+}
+
+// UnixNano returns t as a Unix time, the number of nanoseconds elapsed
+// since January 1, 1970 UTC. The result is undefined if the Unix time
+// in nanoseconds cannot be represented by an int64 (a date before the year
+// 1678 or after 2262). Note that this means the result of calling UnixNano
+// on the zero Time is undefined. The result does not depend on the
+// location associated with t.
+func (t Time) UnixNano() int64 {
+	return t.t.UnixNano()
+}
+
+// Weekday returns the day of the week specified by t.
+func (t Time) Weekday() int {
+	return int(t.t.Weekday())
+}
+
+// Year returns the year in which t occurs.
+func (t Time) Year() int {
+	return t.t.Year()
+}
+
+// YearDay returns the day of the year specified by t, in the range [1,365]
+// for non-leap years, and [1,366] in leap years.
+func (t Time) YearDay() int {
+	return t.t.YearDay()
+}
+
+// timeLayouts contains predefined layouts used by the ParseTime function.
+//
+// This list of layouts is the same used by Hugo's time function. It is
+// copyright 2017 The Hugo Authors and licensed under the Apache license.
+// See https://github.com/gohugoio/hugo/blob/master/tpl/time/time.go.
+var timeLayouts = []string{
+	time.RFC3339,
+	"2006-01-02T15:04:05", // iso8601 without timezone
+	time.RFC1123Z,
+	time.RFC1123,
+	time.RFC822Z,
+	time.RFC822,
+	time.RFC850,
+	time.ANSIC,
+	time.UnixDate,
+	time.RubyDate,
+	"2006-01-02 15:04:05.999999999 -0700 MST", // Time.String()
+	"2006-01-02",
+	"02 Jan 2006",
+	"2006-01-02T15:04:05-0700", // RFC3339 without timezone hh:mm colon
+	"2006-01-02 15:04:05 -07:00",
+	"2006-01-02 15:04:05 -0700",
+	"2006-01-02 15:04:05Z07:00", // RFC3339 without T
+	"2006-01-02 15:04:05Z0700",  // RFC3339 without T or timezone hh:mm colon
+	"2006-01-02 15:04:05",
+	time.Kitchen,
+	time.Stamp,
+	time.StampMilli,
+	time.StampMicro,
+	time.StampNano,
+}

--- a/templates/builtin/time_test.go
+++ b/templates/builtin/time_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2021 Open2b Software Snc. All rights reserved.
+// https://www.open2b.com
+
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package builtin
+
+import (
+	"testing"
+	"time"
+)
+
+var parseTimeTests = []struct {
+	value    string
+	expected string
+}{
+	{"2021-03-27T11:21:14.964553+01:00", "2021-03-27T11:21:14.964553+01:00"},
+	{"2021-03-27T11:21:14+01:00", "2021-03-27T11:21:14+01:00"},
+	{"2021-03-27T11:21:14", "2021-03-27T11:21:14Z"},
+	{"Sat, 27 Mar 2021 11:21:14 +0100", "2021-03-27T11:21:14+01:00"},
+	{"Sat, 27 Mar 2021 11:21:14 CET", "2021-03-27T11:21:14+01:00"},
+	{"27 Mar 21 11:21 +0100", "2021-03-27T11:21:00+01:00"},
+	{"27 Mar 21 11:21 CET", "2021-03-27T11:21:00+01:00"},
+	{"Saturday, 27-Mar-21 11:21:14 CET", "2021-03-27T11:21:14+01:00"},
+	{"Sat Mar 27 11:21:14 2021", "2021-03-27T11:21:14Z"},
+	{"Sat Mar 27 11:21:14 CET 2021", "2021-03-27T11:21:14+01:00"},
+	{"Sat Mar 27 11:21:14 +0100 2021", "2021-03-27T11:21:14+01:00"},
+	{"2021-03-27 11:21:14.964553 +0100 CET", "2021-03-27T11:21:14.964553+01:00"},
+	{"2021-03-27", "2021-03-27T00:00:00Z"},
+	{"27 Mar 2021", "2021-03-27T00:00:00Z"},
+	{"2021-03-27T11:21:14+0100", "2021-03-27T11:21:14+01:00"},
+	{"2021-03-27 11:21:14 +01:00", "2021-03-27T11:21:14+01:00"},
+	{"2021-03-27 11:21:14 +0100", "2021-03-27T11:21:14+01:00"},
+	{"2021-03-27 11:21:14+01:00", "2021-03-27T11:21:14+01:00"},
+	{"2021-03-27 11:21:14+0100", "2021-03-27T11:21:14+01:00"},
+	{"2021-03-27 11:21:14", "2021-03-27T11:21:14Z"},
+	{"11:21AM", "0000-01-01T11:21:00Z"},
+	{"Mar 27 11:21:14", "0000-03-27T11:21:14Z"},
+	{"Mar 27 11:21:14.964", "0000-03-27T11:21:14.964Z"},
+	{"Mar 27 11:21:14.964553", "0000-03-27T11:21:14.964553Z"},
+	{"Mar 27 11:21:14.964553000", "0000-03-27T11:21:14.964553Z"},
+}
+
+func TestParseTime(t *testing.T) {
+	for _, cas := range parseTimeTests {
+		tm, err := ParseTime("", cas.value)
+		if err != nil {
+			t.Fatalf("source: %q, got error %q, expecting %q\n", cas.value, err, cas.expected)
+		}
+		if got := tm.t.Format(time.RFC3339Nano); got != cas.expected {
+			t.Errorf("source: %q, got %q, expecting %q\n", cas.value, got, cas.expected)
+		}
+	}
+}
+
+var t1, _ = ParseTime(time.RFC3339Nano, "2021-03-27T11:21:14.964553+01:00")
+var t2, _ = ParseTime(time.RFC3339Nano, "2021-02-12T10:16:29.370149+01:00")
+
+var sptime = func(t Time) string { return t.t.Format(time.RFC3339Nano) }
+
+var timeTests = []struct {
+	got      string
+	expected string
+}{
+	{sptime(t1.Add(2 * time.Hour)), "2021-03-27T13:21:14.964553+01:00"},
+	{sptime(t1.AddDate(2, 3, 7)), "2023-07-04T11:21:14.964553+02:00"},
+	{spf("%t", t1.After(t2)), "true"},
+	{spf("%t", t1.Before(t2)), "false"},
+	{spf("%v", func() []int { h, m, s := t1.Clock(); return []int{h, m, s} }()), "[11 21 14]"},
+	{spf("%v", func() []int { y, m, d := t1.Date(); return []int{y, int(m), d} }()), "[2021 3 27]"},
+	{spf("%d", t1.Day()), "27"},
+	{spf("%t", t1.Equal(t1)), "true"},
+	{spf("%t", t1.Equal(t2)), "false"},
+	{spf("%s", t1.Format("Monday, 02-Jan-06 15:04:05 MST")), "Saturday, 27-Mar-21 11:21:14 CET"},
+	{spf("%d", t1.Hour()), "11"},
+	{spf("%s", t1.JS()), `new Date("2021-03-27T11:21:14.964+01:00")`},
+	{spf("%s", t1.JSON()), `"2021-03-27T11:21:14+01:00"`},
+	{spf("%d", t1.Minute()), "21"},
+	{spf("%d", t1.Month()), "3"},
+	{spf("%d", t1.Nanosecond()), "964553000"},
+	{spf("%s", t1.Round(3*time.Hour+25*time.Second)), "2021-03-27 12:24:35 +0100 CET"},
+	{spf("%d", t1.Second()), "14"},
+	{spf("%s", t1.String()), "2021-03-27 11:21:14.964553 +0100 CET"},
+	{spf("%s", t1.Sub(t2)), "1033h4m45.594404s"},
+	{spf("%s", t1.Truncate(3*time.Hour+25*time.Second)), "2021-03-27 09:24:10 +0100 CET"},
+	{spf("%s", t1.UTC()), "2021-03-27 10:21:14.964553 +0000 UTC"},
+	{spf("%d", t1.Unix()), "1616840474"},
+	{spf("%d", t1.UnixNano()), "1616840474964553000"},
+	{spf("%d", t1.Weekday()), "6"},
+	{spf("%d", t1.Year()), "2021"},
+	{spf("%d", t1.YearDay()), "86"},
+}
+
+func TestTime(t *testing.T) {
+	for _, expr := range timeTests {
+		if expr.got != expr.expected {
+			t.Errorf("got %q, expecting %q\n", expr.got, expr.expected)
+		}
+	}
+}


### PR DESCRIPTION
This change adds the builtin types 'Time' and 'Duration', 

