### PR TITLE
compiler/checker: document better type checking of a selector

### DIFF
--- a/compiler/checker_expressions.go
+++ b/compiler/checker_expressions.go
@@ -838,7 +838,7 @@ func (tc *typechecker) typeof(expr ast.Expression, typeExpected bool) *typeInfo 
 		}
 		method, trans, ok := tc.methodByName(t, expr.Ident)
 		if ok {
-			// Method selector.
+			// Method value.
 			switch trans {
 			case receiverAddAddress:
 				if t.Addressable() {


### PR DESCRIPTION
This commit does not change the behavior. It merges two "if" in one and add some documentation.