### PR TITLE
all: use 'native' and 'non-native' instead of 'predefined' and 'Scriggo'

### DIFF
--- a/cmd/scriggo/help.go
+++ b/cmd/scriggo/help.go
@@ -356,7 +356,7 @@ Arbitrary limitations
         * 256 function literal declarations plus unique functions calls per
         function
     * 256 types available per function
-    * 256 unique predefined functions per function
+    * 256 unique native functions per function
     * 16384 integer values per function
     * 256 string values per function
     * 16384 floating-point values per function

--- a/cmd/scriggo/sources.go
+++ b/cmd/scriggo/sources.go
@@ -786,7 +786,7 @@ Arbitrary limitations
         * 256 function literal declarations plus unique functions calls per
         function
     * 256 types available per function
-    * 256 unique predefined functions per function
+    * 256 unique native functions per function
     * 16384 integer values per function
     * 256 string values per function
     * 16384 floating-point values per function

--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -490,25 +490,25 @@ type Func struct {
 }
 
 // Upvar represents a variable defined outside function body. Even package level
-// variables (predefined or not) are considered upvars.
+// variables (native or non-native) are considered upvars.
 type Upvar struct {
 
-	// PredefinedPkg is the name of the predefined package which holds a
-	// predefined Upvar. If Upvar is not a predefined Upvar then PredefinedName
+	// NativePkg is the name of the native package which holds a
+	// native Upvar. If Upvar is not a native Upvar then NativeName
 	// is an empty string.
-	PredefinedPkg string
+	NativePkg string
 
-	// PredefinedName is the name of the predefined declaration of a predefined
-	// Upvar. If Upvar is not a predefined Upvar then PredefinedName is an empty
+	// NativeName is the name of the native declaration of a native
+	// Upvar. If Upvar is not a native Upvar then NativeName is an empty
 	// string.
-	PredefinedName string
+	NativeName string
 
-	// PredefinedValue is the value of the predefined variable Upvar. If Upvar
-	// is not a predefined then Upvar is nil.
-	PredefinedValue *reflect.Value
+	// NativeValue is the value of the native variable Upvar. If Upvar
+	// is not native then Upvar is nil.
+	NativeValue *reflect.Value
 
 	// Declaration is the ast node where Upvar is defined. If Upvar is a
-	// predefined var then Declaration is nil.
+	// native var then Declaration is nil.
 	Declaration Node
 
 	// Index indexes the Upvars slice of the parent function.

--- a/compiler/builder_instructions.go
+++ b/compiler/builder_instructions.go
@@ -149,14 +149,14 @@ func (fb *functionBuilder) emitCallIndirect(f int8, numVariadic int8, shift runt
 	fn.Body = append(fn.Body, runtime.Instruction{Op: runtime.Operation(shift[0]), A: shift[1], B: shift[2], C: shift[3]})
 }
 
-// emitCallPredefined appends a new "CallPredefined" instruction to the function body.
+// emitCallNative appends a new "CallNative" instruction to the function body.
 //
 //     p.F()
 //
-func (fb *functionBuilder) emitCallPredefined(f int8, numVariadic int8, shift runtime.StackShift, pos *ast.Position) {
+func (fb *functionBuilder) emitCallNative(f int8, numVariadic int8, shift runtime.StackShift, pos *ast.Position) {
 	fb.addPosAndPath(pos)
 	fn := fb.fn
-	fn.Body = append(fn.Body, runtime.Instruction{Op: runtime.OpCallPredefined, A: f, C: numVariadic})
+	fn.Body = append(fn.Body, runtime.Instruction{Op: runtime.OpCallNative, A: f, C: numVariadic})
 	fn.Body = append(fn.Body, runtime.Instruction{Op: runtime.Operation(shift[0]), A: shift[1], B: shift[2], C: shift[3]})
 }
 
@@ -465,10 +465,10 @@ func (fb *functionBuilder) emitLen(s, l int8, t reflect.Type) {
 //
 //     z = p.f
 //
-func (fb *functionBuilder) emitLoadFunc(predefined bool, f int8, z int8) {
+func (fb *functionBuilder) emitLoadFunc(native bool, f int8, z int8) {
 	fn := fb.fn
 	var a int8
-	if predefined {
+	if native {
 		a = 1
 	}
 	fn.Body = append(fn.Body, runtime.Instruction{Op: runtime.OpLoadFunc, A: a, B: f, C: z})

--- a/compiler/checker.go
+++ b/compiler/checker.go
@@ -25,7 +25,7 @@ const (
 	templateMod
 )
 
-// typecheck makes a type check on tree. A map of predefined packages may be
+// typecheck makes a type check on tree. A map of native packages may be
 // provided. deps must contain dependencies in case of package initialization
 // (program or template import/extend).
 // tree may be altered during the type checking.
@@ -163,14 +163,14 @@ type typechecker struct {
 
 	path string
 
-	precompiledPkgs PackageLoader
+	nativePackages PackageLoader
 
 	// universe is the outermost scope.
 	universe typeCheckerScope
 
 	// A globalScope is a scope between the universe and the file/package block.
 	// In Go there is not an equivalent concept. In scripts and templates, the
-	// declarations of the predefined package 'main' are added to this scope;
+	// declarations of the native package 'main' are added to this scope;
 	// this makes possible, in templates, to access such declarations from every
 	// page, including imported and extended ones.
 	globalScope typeCheckerScope
@@ -230,16 +230,15 @@ type typechecker struct {
 	scriptFuncOrMacroDecl bool
 
 	// types refers the types of the current compilation and it is used to
-	// create and manipulate types and values, both predefined and defined only
-	// by Scriggo.
+	// create and manipulate types and values, both native and non-native.
 	types *types.Types
 
 	// env is passed to the showFunc function and implements only the TypeOf method.
 	env *env
 
 	// structDeclPkg contains, for every struct literal and defined type with
-	// underlying type 'struct' denoted in Scriggo, the package in which it has
-	// been denoted.
+	// underlying non-native type 'struct', the package in which it has been
+	// denoted.
 	//
 	// TODO(marco): now that issue #367 is resolved, is this comment still relevant?
 	// In theory, we should keep track of the package in which the field
@@ -254,7 +253,7 @@ type typechecker struct {
 
 // newTypechecker creates a new type checker. A global scope may be provided
 // for scripts and templates.
-func newTypechecker(compilation *compilation, path string, opts checkerOptions, globalScope typeCheckerScope, precompiledPkgs PackageLoader) *typechecker {
+func newTypechecker(compilation *compilation, path string, opts checkerOptions, globalScope typeCheckerScope, nativePackages PackageLoader) *typechecker {
 	tt := types.NewTypes()
 	tc := typechecker{
 		compilation:      compilation,
@@ -269,7 +268,7 @@ func newTypechecker(compilation *compilation, path string, opts checkerOptions, 
 		types:            tt,
 		env:              &env{tt.Runtime(), nil},
 		structDeclPkg:    map[reflect.Type]string{},
-		precompiledPkgs:  precompiledPkgs,
+		nativePackages:   nativePackages,
 	}
 	if len(opts.formatTypes) > 0 {
 		tc.universe = typeCheckerScope{}

--- a/compiler/checker_expressions.go
+++ b/compiler/checker_expressions.go
@@ -144,9 +144,9 @@ func (tc *typechecker) checkIdentifier(ident *ast.Identifier, using bool) *typeI
 
 	// Handle predeclared variables in templates and scripts.
 	if tc.opts.modality == templateMod || tc.opts.modality == scriptMod {
-		// The identifier refers to a predefined value that is an up value for
-		// the current function.
-		if ti.IsPredefined() && tc.isUpVar(ident.Name) {
+		// The identifier refers to a native value that is an up value for the
+		// current function.
+		if ti.IsNative() && tc.isUpVar(ident.Name) {
 			// The type info contains a *reflect.Value, so it is a variable.
 			if rv, ok := ti.value.(*reflect.Value); ok {
 				// Get the list of the nested functions, from the outermost to
@@ -159,15 +159,15 @@ func (tc *typechecker) checkIdentifier(ident *ast.Identifier, using bool) *typeI
 					funcLiteralInTemplate := tc.opts.modality == templateMod && nestedFuncs[0].Ident == nil
 					if funcLiteralInTemplate || tc.opts.modality == scriptMod {
 						upvar := ast.Upvar{
-							PredefinedName:  ident.Name,
-							PredefinedPkg:   ident.Name,
-							PredefinedValue: rv,
-							Index:           -1,
+							NativeName:  ident.Name,
+							NativePkg:   ident.Name,
+							NativeValue: rv,
+							Index:       -1,
 						}
 						for _, fn := range nestedFuncs {
 							add := true
 							for i, uv := range fn.Upvars {
-								if uv.PredefinedValue == upvar.PredefinedValue {
+								if uv.NativeValue == upvar.NativeValue {
 									upvar.Index = int16(i)
 									add = false
 									break
@@ -810,18 +810,18 @@ func (tc *typechecker) typeof(expr ast.Expression, typeExpected bool) *typeInfo 
 				if !ok {
 					panic(tc.errorf(expr, "undefined: %v", expr))
 				}
-				// v is a predefined variable.
+				// v is a native variable.
 				if rv, ok := v.value.(*reflect.Value); v.Addressable() && ok {
 					upvar := ast.Upvar{
-						PredefinedName:  expr.Ident,
-						PredefinedPkg:   ident.Name,
-						PredefinedValue: rv,
-						Index:           -1,
+						NativeName:  expr.Ident,
+						NativePkg:   ident.Name,
+						NativeValue: rv,
+						Index:       -1,
 					}
 					for _, fn := range tc.nestedFuncs() {
 						add := true
 						for i, uv := range fn.Upvars {
-							if uv.PredefinedValue == upvar.PredefinedValue {
+							if uv.NativeValue == upvar.NativeValue {
 								upvar.Index = int16(i)
 								add = false
 								break

--- a/compiler/checker_test.go
+++ b/compiler/checker_test.go
@@ -693,7 +693,7 @@ func evaluatedButNotUsed(v string) string {
 	return v + " evaluated but not used"
 }
 
-// checkerStmts contains some Scriggo snippets with expected type-checker error
+// checkerStmts contains some snippets with expected type-checker error
 // (or empty string if the type checking is valid). Error messages are based
 // upon Go 1.14. Tests are subdivided for categories. Each category has a title
 // (indicated by a comment), and it's split in two parts: correct source codes
@@ -1669,8 +1669,8 @@ func TestCheckerRemoveEnv(t *testing.T) {
 		p.Env1(1)
 		p.EnvVar(1,2,3,4,5)
 	}`
-	predefined := predefinedPackages{"p": p}
-	tree, err := ParseProgram(loaders(mapStringLoader{"main": main}, predefined))
+	native := nativePackages{"p": p}
+	tree, err := ParseProgram(loaders(mapStringLoader{"main": main}, native))
 	if err != nil {
 		t.Errorf("TestCheckerRemoveEnv returned parser error: %s", err)
 		return
@@ -1678,7 +1678,7 @@ func TestCheckerRemoveEnv(t *testing.T) {
 	opts := checkerOptions{
 		modality: programMod,
 	}
-	_, err = typecheck(tree, predefined, opts)
+	_, err = typecheck(tree, native, opts)
 	if err != nil {
 		t.Errorf("TestCheckerRemoveEnv returned type check error: %s", err)
 		return

--- a/compiler/checker_util.go
+++ b/compiler/checker_util.go
@@ -266,13 +266,13 @@ func deferGoBuiltin(name string) *typeInfo {
 			env.Println(args...)
 		}
 	case "recover":
-		// This predefined function should only be used with the 'go'
-		// statement and not the 'defer' statement.
+		// This native function should only be used with the 'go' statement
+		// and not the 'defer' statement.
 		fun = func() {}
 	}
 	rv := reflect.ValueOf(fun)
 	return &typeInfo{
-		Properties: propertyHasValue | propertyIsPredefined,
+		Properties: propertyHasValue | propertyIsNative,
 		Type:       removeEnvArg(rv.Type(), false),
 		value:      rv,
 	}
@@ -286,9 +286,9 @@ func (tc *typechecker) emptyMethodSet(interf reflect.Type) bool {
 // fieldByName returns the struct field with the given name if such field
 // exists and can be accessed, else returns an error.
 //
-// If name is non-exported and the type is declared in Scriggo then name is
-// transformed and the new name is returned. For further information about this
-// check the documentation of the type checking of an *ast.StructType.
+// If name is non-exported and the type is not native then name is transformed
+// and the new name is returned. For further information about this check the
+// documentation of the type checking of an *ast.StructType.
 func (tc *typechecker) fieldByName(t *typeInfo, name string) (*typeInfo, string, error) {
 
 	typ := t.Type
@@ -550,7 +550,7 @@ func (tc *typechecker) methodByName(t *typeInfo, name string) (*typeInfo, receiv
 				ti := &typeInfo{
 					Type:       removeEnvArg(methExpr.Type(), false),
 					value:      methExpr,
-					Properties: propertyIsPredefined | propertyHasValue,
+					Properties: propertyIsNative | propertyHasValue,
 				}
 				return ti, receiverNoTransform, true
 			}
@@ -561,7 +561,7 @@ func (tc *typechecker) methodByName(t *typeInfo, name string) (*typeInfo, receiv
 			return &typeInfo{
 				Type:       removeEnvArg(method.Type, true),
 				value:      method.Func,
-				Properties: propertyIsPredefined | propertyHasValue,
+				Properties: propertyIsNative | propertyHasValue,
 			}, receiverNoTransform, true
 		}
 		return nil, receiverNoTransform, false
@@ -574,7 +574,7 @@ func (tc *typechecker) methodByName(t *typeInfo, name string) (*typeInfo, receiv
 				Type:       removeEnvArg(method.Type, true),
 				value:      name,
 				MethodType: methodValueInterface,
-				Properties: propertyIsPredefined | propertyHasValue,
+				Properties: propertyIsNative | propertyHasValue,
 			}
 			return ti, receiverNoTransform, true
 		}
@@ -588,7 +588,7 @@ func (tc *typechecker) methodByName(t *typeInfo, name string) (*typeInfo, receiv
 		ti := &typeInfo{
 			Type:       removeEnvArg(method.Type(), false),
 			value:      methodExplicitRcvr.Func,
-			Properties: propertyIsPredefined | propertyHasValue,
+			Properties: propertyIsNative | propertyHasValue,
 			MethodType: methodValueConcrete,
 		}
 		// Check if pointer is defined on T or *T when called on a *T receiver.
@@ -614,7 +614,7 @@ func (tc *typechecker) methodByName(t *typeInfo, name string) (*typeInfo, receiv
 			return &typeInfo{
 				Type:       removeEnvArg(method.Type(), false),
 				value:      methodExplicitRcvr.Func,
-				Properties: propertyIsPredefined | propertyHasValue,
+				Properties: propertyIsNative | propertyHasValue,
 				MethodType: methodValueConcrete,
 			}, receiverAddAddress, true
 		}
@@ -686,7 +686,7 @@ func (tc *typechecker) nilOf(t reflect.Type) *typeInfo {
 	switch t.Kind() {
 	case reflect.Func:
 		return &typeInfo{
-			Properties: propertyHasValue | propertyIsPredefined,
+			Properties: propertyHasValue | propertyIsNative,
 			Type:       t,
 			value:      tc.types.Zero(t),
 		}

--- a/compiler/disassembler.go
+++ b/compiler/disassembler.go
@@ -106,7 +106,7 @@ func Disassemble(main *runtime.Function, globals []Global, n int) map[string][]b
 				allFunctions = append(allFunctions, sf)
 			}
 		}
-		for _, nf := range fn.Predefined {
+		for _, nf := range fn.NativeFunctions {
 			if packages, ok := importsByPkg[fn.Pkg]; ok {
 				packages[nf.Package()] = struct{}{}
 			} else {
@@ -279,7 +279,7 @@ func disassembleFunction(b *bytes.Buffer, globals []Global, fn *runtime.Function
 			b.WriteByte('\n')
 		}
 		switch in.Op {
-		case runtime.OpCallFunc, runtime.OpCallMacro, runtime.OpCallIndirect, runtime.OpCallPredefined,
+		case runtime.OpCallFunc, runtime.OpCallMacro, runtime.OpCallIndirect, runtime.OpCallNative,
 			runtime.OpTailCall, runtime.OpSlice, runtime.OpStringSlice:
 			addr += 1
 		case runtime.OpDefer:
@@ -364,7 +364,7 @@ func disassembleInstruction(fn *runtime.Function, globals []Global, addr runtime
 		s += " " + disassembleOperand(fn, c, kind, false)
 	case runtime.OpBreak, runtime.OpContinue, runtime.OpGoto:
 		s += " " + strconv.Itoa(int(decodeUint24(a, b, c)))
-	case runtime.OpCallFunc, runtime.OpCallMacro, runtime.OpCallIndirect, runtime.OpCallPredefined, runtime.OpTailCall, runtime.OpDefer:
+	case runtime.OpCallFunc, runtime.OpCallMacro, runtime.OpCallIndirect, runtime.OpCallNative, runtime.OpTailCall, runtime.OpDefer:
 		if a != runtime.CurrentFunction {
 			switch op {
 			case runtime.OpCallFunc, runtime.OpCallMacro, runtime.OpTailCall:
@@ -374,8 +374,8 @@ func disassembleInstruction(fn *runtime.Function, globals []Global, addr runtime
 				s += " " + "("
 				s += disassembleOperand(fn, a, reflect.Interface, false)
 				s += ")"
-			case runtime.OpCallPredefined:
-				nf := fn.Predefined[uint8(a)]
+			case runtime.OpCallNative:
+				nf := fn.NativeFunctions[uint8(a)]
 				s += " " + packageName(nf.Package()) + "." + nf.Name()
 			case runtime.OpDefer:
 				s += " " + disassembleOperand(fn, a, reflect.Interface, false)
@@ -383,7 +383,7 @@ func disassembleInstruction(fn *runtime.Function, globals []Global, addr runtime
 		}
 		grow := fn.Body[addr+1]
 		stackShift := runtime.StackShift{int8(grow.Op), grow.A, grow.B, grow.C}
-		if c != runtime.NoVariadicArgs && (op == runtime.OpCallIndirect || op == runtime.OpCallPredefined || op == runtime.OpDefer) {
+		if c != runtime.NoVariadicArgs && (op == runtime.OpCallIndirect || op == runtime.OpCallNative || op == runtime.OpDefer) {
 			s += " ..." + strconv.Itoa(int(c))
 		}
 		_, _, typ := funcNameType(fn, a, addr, op)
@@ -538,8 +538,8 @@ func disassembleInstruction(fn *runtime.Function, globals []Global, addr runtime
 				s += " " + packageName(f.Pkg) + "." + f.Name
 				s += " " + disassembleOperand(fn, c, reflect.Interface, false)
 			}
-		} else { // LoadFunc (predefined).
-			f := fn.Predefined[uint8(b)]
+		} else { // LoadFunc (native).
+			f := fn.NativeFunctions[uint8(b)]
 			s += " " + packageName(f.Package()) + "." + f.Name()
 			s += " " + disassembleOperand(fn, c, reflect.Interface, false)
 		}
@@ -725,9 +725,9 @@ func funcNameType(fn *runtime.Function, index int8, addr runtime.Addr, op runtim
 		typ := fn.Functions[index].Type
 		name := fn.Functions[index].Name
 		return macro, name, typ
-	case runtime.OpCallPredefined:
-		name := fn.Predefined[index].Name()
-		typ := reflect.TypeOf(fn.Predefined[index].Func())
+	case runtime.OpCallNative:
+		name := fn.NativeFunctions[index].Name()
+		typ := reflect.TypeOf(fn.NativeFunctions[index].Func())
 		return false, name, typ
 	case runtime.OpCallIndirect, runtime.OpDefer:
 		return false, "", fn.DebugInfo[addr].FuncType
@@ -981,10 +981,10 @@ var operationName = [...]string{
 
 	runtime.OpBreak: "Break",
 
-	runtime.OpCallFunc:       "Call",
-	runtime.OpCallIndirect:   "Call",
-	runtime.OpCallMacro:      "Call",
-	runtime.OpCallPredefined: "Call",
+	runtime.OpCallFunc:     "Call",
+	runtime.OpCallIndirect: "Call",
+	runtime.OpCallMacro:    "Call",
+	runtime.OpCallNative:   "Call",
 
 	runtime.OpCap: "Cap",
 

--- a/compiler/emitter_assignment.go
+++ b/compiler/emitter_assignment.go
@@ -264,7 +264,7 @@ func (em *emitter) emitAssignmentOperation(addr address, rh ast.Expression) {
 		em.changeRegister(false, b, c1, typ, typ)
 		em.changeRegister(false, c, c2, typ, typ)
 		index := em.fb.complexOperationIndex(operatorFromAssignmentType(addr.operator), false)
-		em.fb.emitCallPredefined(index, 0, stackShift, addr.pos)
+		em.fb.emitCallNative(index, 0, stackShift, addr.pos)
 		em.changeRegister(false, ret, c, typ, typ)
 		em.fb.exitScope()
 		addr.assign(false, c, typ)

--- a/compiler/emitter_statements.go
+++ b/compiler/emitter_statements.go
@@ -545,10 +545,10 @@ func (em *emitter) emitAssignmentNode(node *ast.Assignment) {
 //
 func (em *emitter) emitImport(node *ast.Import, isTemplate bool) []*runtime.Function {
 
-	// If the imported package is predefined the emitter does not have to do
-	// anything: the predefined values have already been added to the type infos
+	// If the imported package is native the emitter does not have to do
+	// anything: the native values have already been added to the type infos
 	// of the tree, and the init functions have already been called when gc
-	// imported the predefined package.
+	// imported the native package.
 	if node.Tree == nil {
 		return nil
 	}
@@ -610,7 +610,7 @@ func (em *emitter) emitImport(node *ast.Import, isTemplate bool) []*runtime.Func
 			if importName != "" {
 				name = importName + "." + name
 			}
-			em.fnStore.makeAvailableScriggoFn(targetPkg, name, fn)
+			em.fnStore.makeAvailableFunction(targetPkg, name, fn)
 		}
 
 		// Add the imported variables.
@@ -618,7 +618,7 @@ func (em *emitter) emitImport(node *ast.Import, isTemplate bool) []*runtime.Func
 			if importName != "" {
 				name = importName + "." + name
 			}
-			em.varStore.bindScriggoPackageVar(targetPkg, name, v)
+			em.varStore.bindPackageVar(targetPkg, name, v)
 		}
 	}
 

--- a/compiler/emitter_var_store.go
+++ b/compiler/emitter_var_store.go
@@ -13,8 +13,8 @@ import (
 	"github.com/open2b/scriggo/runtime"
 )
 
-// A varStore holds information about closure variables, predefined variables
-// and package-level variables during the emission.
+// A varStore holds information about closure variables, native variables and
+// package-level variables during the emission.
 type varStore struct {
 
 	// emitter is a reference to the current emitter.
@@ -25,12 +25,12 @@ type varStore struct {
 	// read-only.
 	indirectVars map[*ast.Identifier]bool
 
-	predefVarRef map[*runtime.Function]map[*reflect.Value]int16
+	nativeVarRef map[*runtime.Function]map[*reflect.Value]int16
 
-	// Holds all Scriggo-defined and pre-predefined global variables.
+	// Holds all native and non-native global variables.
 	globals []Global
 
-	scriggoPackageVarRefs map[*ast.Package]map[string]int16
+	packageVarRefs map[*ast.Package]map[string]int16
 
 	closureVars map[*runtime.Function]map[string]int16
 }
@@ -38,11 +38,11 @@ type varStore struct {
 // newVarStore returns a new *varStore.
 func newVarStore(emitter *emitter, indirectVars map[*ast.Identifier]bool) *varStore {
 	return &varStore{
-		emitter:               emitter,
-		predefVarRef:          map[*runtime.Function]map[*reflect.Value]int16{},
-		indirectVars:          indirectVars,
-		scriggoPackageVarRefs: map[*ast.Package]map[string]int16{},
-		closureVars:           map[*runtime.Function]map[string]int16{},
+		emitter:        emitter,
+		nativeVarRef:   map[*runtime.Function]map[*reflect.Value]int16{},
+		indirectVars:   indirectVars,
+		packageVarRefs: map[*ast.Package]map[string]int16{},
+		closureVars:    map[*runtime.Function]map[string]int16{},
 	}
 }
 
@@ -54,22 +54,22 @@ func (vs *varStore) setClosureVar(fn *runtime.Function, name string, index int16
 	vs.closureVars[fn][name] = index
 }
 
-// bindScriggoPackageVar binds name to the package variable defined in Scriggo
-// located at the given index, making it available for use in pkg.
-func (vs *varStore) bindScriggoPackageVar(pkg *ast.Package, name string, index int16) {
-	if vs.scriggoPackageVarRefs[pkg] == nil {
-		vs.scriggoPackageVarRefs[pkg] = map[string]int16{}
+// bindPackageVar binds name to the non-native package variable located at the
+// given index, making it available for use in pkg.
+func (vs *varStore) bindPackageVar(pkg *ast.Package, name string, index int16) {
+	if vs.packageVarRefs[pkg] == nil {
+		vs.packageVarRefs[pkg] = map[string]int16{}
 	}
-	vs.scriggoPackageVarRefs[pkg][name] = index
+	vs.packageVarRefs[pkg][name] = index
 }
 
-func (vs *varStore) createScriggoPackageVar(pkg *ast.Package, global Global) int16 {
+func (vs *varStore) createPackageVar(pkg *ast.Package, global Global) int16 {
 	index := int16(len(vs.globals))
 	vs.globals = append(vs.globals, global)
-	if vs.scriggoPackageVarRefs[pkg] == nil {
-		vs.scriggoPackageVarRefs[pkg] = map[string]int16{}
+	if vs.packageVarRefs[pkg] == nil {
+		vs.packageVarRefs[pkg] = map[string]int16{}
 	}
-	vs.scriggoPackageVarRefs[pkg][global.Name] = index
+	vs.packageVarRefs[pkg][global.Name] = index
 	return index
 }
 
@@ -78,11 +78,11 @@ func (vs *varStore) mustBeDeclaredAsIndirect(v *ast.Identifier) bool {
 	return vs.indirectVars[v]
 }
 
-// predefVarIndex returns the index of the predefined variable v. If v is not
+// nativeVarIndex returns the index of the native variable v. If v is not
 // available in the global slice then it is added by this call.
-func (vs *varStore) predefVarIndex(v *reflect.Value, pkg, name string) int16 {
+func (vs *varStore) nativeVarIndex(v *reflect.Value, pkg, name string) int16 {
 	currFn := vs.emitter.fb.fn
-	if index, ok := vs.predefVarRef[currFn][v]; ok {
+	if index, ok := vs.nativeVarRef[currFn][v]; ok {
 		return index
 	}
 	index := int16(len(vs.globals))
@@ -90,19 +90,19 @@ func (vs *varStore) predefVarIndex(v *reflect.Value, pkg, name string) int16 {
 	if !v.IsNil() {
 		g.Value = v.Interface()
 	}
-	if vs.predefVarRef[currFn] == nil {
-		vs.predefVarRef[currFn] = map[*reflect.Value]int16{}
+	if vs.nativeVarRef[currFn] == nil {
+		vs.nativeVarRef[currFn] = map[*reflect.Value]int16{}
 	}
 	vs.globals = append(vs.globals, g)
-	vs.predefVarRef[currFn][v] = index
+	vs.nativeVarRef[currFn][v] = index
 	return index
 }
 
-func (vs *varStore) setPredefVarRef(fn *runtime.Function, v *reflect.Value, index int16) {
-	if vs.predefVarRef[fn] == nil {
-		vs.predefVarRef[fn] = map[*reflect.Value]int16{}
+func (vs *varStore) setNativeVarRef(fn *runtime.Function, v *reflect.Value, index int16) {
+	if vs.nativeVarRef[fn] == nil {
+		vs.nativeVarRef[fn] = map[*reflect.Value]int16{}
 	}
-	vs.predefVarRef[fn][v] = index
+	vs.nativeVarRef[fn][v] = index
 }
 
 // getGlobals returns the slice of all Globals collected during the emission.
@@ -135,16 +135,16 @@ func (vs *varStore) nonLocalVarIndex(v ast.Expression) (index int, ok bool) {
 	currFn := vs.emitter.fb.fn
 	currPkg := vs.emitter.pkg
 
-	// v is a predefined variable.
-	if ti != nil && ti.IsPredefined() {
-		index := vs.predefVarIndex(ti.value.(*reflect.Value), ti.PredefPackageName, name)
+	// v is a native variable.
+	if ti != nil && ti.IsNative() {
+		index := vs.nativeVarIndex(ti.value.(*reflect.Value), ti.NativePackageName, name)
 		return int(index), true
 	}
 
 	if index, ok := vs.closureVars[currFn][fullName]; ok {
 		return int(index), true
 	}
-	if index, ok := vs.scriggoPackageVarRefs[currPkg][fullName]; ok {
+	if index, ok := vs.packageVarRefs[currPkg][fullName]; ok {
 		return int(index), true
 	}
 	return 0, false

--- a/compiler/limit_exceeded_error_test.go
+++ b/compiler/limit_exceeded_error_test.go
@@ -70,8 +70,8 @@ func TestFunctionsLimit(t *testing.T) {
 			if _, ok := r.(*LimitExceededError); ok {
 				// The type of the error is correct. Now check if the
 				// test panicked at the correct index.
-				if maxScriggoFunctionsCount != i {
-					t.Fatalf("test should have panicked at index %d, but it panicked at index %d", maxScriggoFunctionsCount, i)
+				if maxFunctionsCount != i {
+					t.Fatalf("test should have panicked at index %d, but it panicked at index %d", maxFunctionsCount, i)
 				}
 			} else {
 				t.Fatalf("expecting a LimitExceededError, got error %s (of type %T)", r, r)

--- a/compiler/parser_program.go
+++ b/compiler/parser_program.go
@@ -18,7 +18,7 @@ import (
 func ParseProgram(packages PackageLoader) (*ast.Tree, error) {
 
 	trees := map[string]*ast.Tree{}
-	predefined := map[string]bool{}
+	native := map[string]bool{}
 
 	main := ast.NewImport(nil, nil, "main")
 
@@ -35,7 +35,7 @@ func ParseProgram(packages PackageLoader) (*ast.Tree, error) {
 			imports = imports[:last]
 			continue
 		}
-		if _, ok := predefined[n.Path]; ok {
+		if _, ok := native[n.Path]; ok {
 			imports = imports[:last]
 			continue
 		}
@@ -53,8 +53,8 @@ func ParseProgram(packages PackageLoader) (*ast.Tree, error) {
 		}
 
 		switch pkg := pkg.(type) {
-		case predefinedPackage:
-			predefined[n.Path] = true
+		case nativePackage:
+			native[n.Path] = true
 		case io.Reader:
 			src, err := ioutil.ReadAll(pkg)
 			if r, ok := pkg.(io.Closer); ok {
@@ -97,7 +97,7 @@ func ParseProgram(packages PackageLoader) (*ast.Tree, error) {
 						}
 					}
 					imp.Tree = tree
-				} else if predefined[imp.Path] {
+				} else if native[imp.Path] {
 					// Skip.
 				} else {
 					// Append the imports in reverse order.
@@ -156,7 +156,7 @@ func ParseScript(src io.Reader, packages PackageLoader, shebang bool) (*ast.Tree
 			return nil, err
 		}
 		switch pkg := pkg.(type) {
-		case predefinedPackage:
+		case nativePackage:
 		case nil:
 			return nil, syntaxError(imp.Pos(), "cannot find package %q", imp.Path)
 		default:

--- a/compiler/parser_template.go
+++ b/compiler/parser_template.go
@@ -242,7 +242,7 @@ func (pp *templateExpansion) expand(nodes []ast.Node) error {
 			// import "path"
 
 			if ext := filepath.Ext(n.Path); ext == "" {
-				// Import a precompiled package (the path has no extension).
+				// Import a native package (the path has no extension).
 				if pp.packages == nil {
 					return syntaxError(n.Pos(), "cannot find package %q", n.Path)
 				}
@@ -251,7 +251,7 @@ func (pp *templateExpansion) expand(nodes []ast.Node) error {
 					return err
 				}
 				switch pkg := pkg.(type) {
-				case predefinedPackage:
+				case nativePackage:
 				case nil:
 					return syntaxError(n.Pos(), "cannot find package %q", n.Path)
 				default:

--- a/compiler/parser_test.go
+++ b/compiler/parser_test.go
@@ -35,8 +35,8 @@ func loaders(loaders ...PackageLoader) PackageLoader {
 	return combinedLoaders(loaders)
 }
 
-// mapStringLoader implements PackageLoader for not predefined packages as a
-// map with string values. Paths and sources are respectively the keys and the
+// mapStringLoader implements PackageLoader for non-native packages as a map
+// with string values. Paths and sources are respectively the keys and the
 // values of the map.
 type mapStringLoader map[string]string
 
@@ -47,9 +47,9 @@ func (r mapStringLoader) Load(path string) (interface{}, error) {
 	return nil, nil
 }
 
-type predefinedPackages map[string]predefinedPackage
+type nativePackages map[string]nativePackage
 
-func (pp predefinedPackages) Load(path string) (interface{}, error) {
+func (pp nativePackages) Load(path string) (interface{}, error) {
 	p := pp[path]
 	return p, nil
 }

--- a/compiler/typeinfo.go
+++ b/compiler/typeinfo.go
@@ -19,7 +19,7 @@ const (
 	propertyIsPackage                                 // is a package
 	propertyPredeclared                               // is predeclared
 	propertyAddressable                               // is addressable
-	propertyIsPredefined                              // is predefined
+	propertyIsNative                                  // is native
 	propertyHasValue                                  // has a value
 	propertyIsMacroDeclaration                        // is macro declaration
 )
@@ -32,7 +32,7 @@ type typeInfo struct {
 	Type              reflect.Type // Type.
 	Properties        properties   // Properties.
 	Constant          constant     // Constant value.
-	PredefPackageName string       // Name of the package. Empty string if not predefined.
+	NativePackageName string       // Name of the package. Empty string if it is not native.
 	MethodType        methodType   // Method type.
 	value             interface{}  // value; for packages has type *Package.
 	valueType         reflect.Type // When value is a predeclared type holds the original type of value.
@@ -100,9 +100,9 @@ func (ti *typeInfo) Addressable() bool {
 	return ti.Properties&propertyAddressable != 0
 }
 
-// IsPredefined reports whether it is predefined.
-func (ti *typeInfo) IsPredefined() bool {
-	return ti.Properties&propertyIsPredefined != 0
+// IsNative reports whether it is native.
+func (ti *typeInfo) IsNative() bool {
+	return ti.Properties&propertyIsNative != 0
 }
 
 // IsBuiltinFunction reports whether it is a builtin function.
@@ -192,7 +192,7 @@ func (ti *typeInfo) HasValue() bool {
 // of value.
 //
 // If ti is not a constant, setValue does nothing. setValue panics if ti
-// represents the predefined nil.
+// represents the predeclared identifier nil.
 //
 // setValue is called at every point where a constant expression is used in a
 // non-constant expression or in a statement. The following examples clarify

--- a/compiler/types/array.go
+++ b/compiler/types/array.go
@@ -11,11 +11,11 @@ import (
 	"strconv"
 )
 
-// ArrayOf is equivalent to reflect.ArrayOf except when elem is a Scriggo type;
-// in such case a new Scriggo array type is created and returned as
+// ArrayOf is equivalent to reflect.ArrayOf except when elem is a non-native
+// type; in such case a new non-native array type is created and returned as
 // reflect.Type.
 func (types *Types) ArrayOf(count int, elem reflect.Type) reflect.Type {
-	if st, ok := elem.(ScriggoType); ok {
+	if st, ok := elem.(Type); ok {
 		return arrayType{
 			Type: reflect.ArrayOf(count, st.Underlying()),
 			elem: st,
@@ -24,11 +24,11 @@ func (types *Types) ArrayOf(count int, elem reflect.Type) reflect.Type {
 	return reflect.ArrayOf(count, elem)
 }
 
-// arrayType represents a composite array type where the element is a Scriggo
-// type.
+// arrayType represents a composite array type where the element is a
+// non-native type.
 type arrayType struct {
 	reflect.Type              // always a reflect implementation of reflect.Type
-	elem         reflect.Type // array element, always a Scriggo type
+	elem         reflect.Type // array element, always a non-native type
 }
 
 // AssignableTo is equivalent to reflect's AssignableTo.
@@ -57,7 +57,7 @@ func (x arrayType) String() string {
 
 // Underlying implements the interface runtime.Wrapper.
 func (x arrayType) Underlying() reflect.Type {
-	assertNotScriggoType(x.Type)
+	assertNativeType(x.Type)
 	return x.Type
 }
 

--- a/compiler/types/chan.go
+++ b/compiler/types/chan.go
@@ -8,10 +8,11 @@ package types
 
 import "reflect"
 
-// ChanOf behaves like reflect.ChanOf except when t is a Scriggo type; in such
-// case a new Scriggo channel type is created and returned as reflect.Type.
+// ChanOf behaves like reflect.ChanOf except when t is a non-native type; in
+// such case a new non-native channel type is created and returned as
+// reflect.Type.
 func (types *Types) ChanOf(dir reflect.ChanDir, t reflect.Type) reflect.Type {
-	if st, ok := t.(ScriggoType); ok {
+	if st, ok := t.(Type); ok {
 		return chanType{
 			Type: reflect.ChanOf(dir, st.Underlying()),
 			elem: st,
@@ -20,11 +21,11 @@ func (types *Types) ChanOf(dir reflect.ChanDir, t reflect.Type) reflect.Type {
 	return reflect.ChanOf(dir, t)
 }
 
-// chanType represents a composite channel type where the element is a Scriggo
-// type.
+// chanType represents a composite channel type where the element is a
+// non-native type.
 type chanType struct {
 	reflect.Type              // always a reflect implementation of reflect.Type
-	elem         reflect.Type // channel element, always a Scriggo type
+	elem         reflect.Type // channel element, always a non-native type
 }
 
 // AssignableTo is equivalent to reflect's AssignableTo.
@@ -63,7 +64,7 @@ func (x chanType) String() string {
 
 // Underlying implements the interface runtime.Wrapper.
 func (x chanType) Underlying() reflect.Type {
-	assertNotScriggoType(x.Type)
+	assertNativeType(x.Type)
 	return x.Type
 }
 

--- a/compiler/types/defined.go
+++ b/compiler/types/defined.go
@@ -10,13 +10,13 @@ import (
 	"reflect"
 )
 
-// definedType represents a type defined in the Scriggo compiled code with a
-// type definition, where the underlying type can be both a type compiled in
-// the Scriggo code or in gc.
+// definedType represents a non-native defined type, where the underlying type
+// can be both a native or non-native type.
 type definedType struct {
 	// The embedded reflect.Type can be both a reflect.Type implemented by the
-	// package "reflect" or a ScriggoType. In the other implementations of
-	// ScriggoType the embedded reflect.Type is always a gc compiled type.
+	// package "reflect" or a types.Type. In the other implementations of
+	// Type the embedded reflect.Type is always implemented by the package
+	// "reflect".
 	reflect.Type
 
 	name string
@@ -39,20 +39,20 @@ func (x definedType) Name() string {
 // AssignableTo is equivalent to reflect's AssignableTo.
 func (x definedType) AssignableTo(u reflect.Type) bool {
 
-	// Both x and u are Scriggo defined types: x is assignable to u only if
+	// Both x and u are non-native defined types: x is assignable to u only if
 	// they are the same type.
 	if T, ok := u.(definedType); ok {
 		return x == T
 	}
 
-	// x is a Scriggo defined type and u is not a defined type: x is
+	// x is a non-native defined type and u is not a defined type: x is
 	// assignable to u only if the underlying type of x is assignable to u.
 	if !isDefinedType(u) {
 		return x.Type.AssignableTo(u)
 	}
 
-	// x is a Scriggo defined type and u is a Go defined type: assignment is
-	// always impossible.
+	// x is a non-native defined type and u is a Go defined type: assignment
+	// is always impossible.
 	return false
 
 }
@@ -80,10 +80,10 @@ func (x definedType) String() string {
 
 // Underlying implements the interface runtime.Wrapper.
 func (x definedType) Underlying() reflect.Type {
-	if st, ok := x.Type.(ScriggoType); ok {
+	if st, ok := x.Type.(Type); ok {
 		return st.Underlying()
 	}
-	assertNotScriggoType(x.Type)
+	assertNativeType(x.Type)
 	return x.Type
 }
 

--- a/compiler/types/func.go
+++ b/compiler/types/func.go
@@ -9,16 +9,17 @@ package types
 import "reflect"
 
 // FuncOf behaves like reflect.FuncOf except when at least one of the
-// parameters is a Scriggo type; in such case a new Scriggo function type is
-// created and returned as reflect.Type.
+// parameters is a non-native type; in such case a new non-native function
+// type is created and returned as reflect.Type.
 func (types *Types) FuncOf(in, out []reflect.Type, variadic bool) reflect.Type {
 
 	// If at least one parameter of the function that is going to be created
-	// is a Scriggo type then such function must be represented with a Scriggo
-	// type. If not, the resulting function can be represented by the reflect
-	// implementation of reflect.Type that can be created with reflect.FuncOf.
+	// is a non-native type then such function must be represented with a
+	// non-native type. If not, the resulting function can be represented by
+	// the reflect implementation of reflect.Type that can be created with
+	// reflect.FuncOf.
 
-	if !containsScriggoType(in) && !containsScriggoType(out) {
+	if containsOnlyNativeTypes(in) && containsOnlyNativeTypes(out) {
 		return reflect.FuncOf(in, out, variadic)
 	}
 
@@ -26,14 +27,14 @@ func (types *Types) FuncOf(in, out []reflect.Type, variadic bool) reflect.Type {
 	outGo := make([]reflect.Type, len(out))
 
 	for i := range in {
-		if st, ok := in[i].(ScriggoType); ok {
+		if st, ok := in[i].(Type); ok {
 			inGo[i] = st.Underlying()
 		} else {
 			inGo[i] = in[i]
 		}
 	}
 	for i := range out {
-		if st, ok := out[i].(ScriggoType); ok {
+		if st, ok := out[i].(Type); ok {
 			outGo[i] = st.Underlying()
 		} else {
 			outGo[i] = out[i]
@@ -90,21 +91,20 @@ func equalReflectTypes(ts1, ts2 []reflect.Type) bool {
 	return true
 }
 
-// containsScriggoType reports whether types contains at least one Scriggo
-// type.
-func containsScriggoType(types []reflect.Type) bool {
+// containsOnlyNativeTypes reports whether types contains only native types.
+func containsOnlyNativeTypes(types []reflect.Type) bool {
 	for _, t := range types {
-		if _, ok := t.(ScriggoType); ok {
-			return true
+		if _, ok := t.(Type); ok {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 type funcType struct {
 	reflect.Type
 
-	// At least one of in and out contains at least one Scriggo type,
+	// At least one of in and out contains at least one non-native type,
 	// otherwise there's no need to create a funcType. in and out must be
 	// pointers because a funcType value must be comparable.
 	in, out *[]reflect.Type
@@ -171,7 +171,7 @@ func (x funcType) String() string {
 
 // Underlying implements the interface runtime.Wrapper.
 func (x funcType) Underlying() reflect.Type {
-	assertNotScriggoType(x.Type)
+	assertNativeType(x.Type)
 	return x.Type
 }
 

--- a/compiler/types/ptr.go
+++ b/compiler/types/ptr.go
@@ -8,10 +8,11 @@ package types
 
 import "reflect"
 
-// PtrTo behaves like reflect.PtrTo except when it is a Scriggo type; in such
-// case a new Scriggo pointer type is created and returned as reflect.Type.
+// PtrTo behaves like reflect.PtrTo except when it is a non-native type; in
+// such case a new non-native pointer type is created and returned as
+// reflect.Type.
 func (types *Types) PtrTo(t reflect.Type) reflect.Type {
-	if st, ok := t.(ScriggoType); ok {
+	if st, ok := t.(Type); ok {
 		return ptrType{
 			Type: reflect.PtrTo(st.Underlying()),
 			elem: st,
@@ -20,8 +21,8 @@ func (types *Types) PtrTo(t reflect.Type) reflect.Type {
 	return reflect.PtrTo(t)
 }
 
-// ptrType represents a composite pointer type where the element is a Scriggo
-// type.
+// ptrType represents a composite pointer type where the element is a
+// non-native type.
 type ptrType struct {
 	reflect.Type
 	elem reflect.Type // Cannot be nil.
@@ -53,7 +54,7 @@ func (x ptrType) String() string {
 
 // Underlying implements the interface runtime.Wrapper.
 func (x ptrType) Underlying() reflect.Type {
-	assertNotScriggoType(x.Type)
+	assertNativeType(x.Type)
 	return x.Type
 }
 

--- a/compiler/types/slice.go
+++ b/compiler/types/slice.go
@@ -8,10 +8,11 @@ package types
 
 import "reflect"
 
-// SliceOf behaves like reflect.SliceOf except when elem is a Scriggo type; in
-// such case a new Scriggo slice type is created and returned as reflect.Type.
+// SliceOf behaves like reflect.SliceOf except when elem is a non-native type;
+// in such case a new non-native slice type is created and returned as
+// reflect.Type.
 func (types *Types) SliceOf(t reflect.Type) reflect.Type {
-	if st, ok := t.(ScriggoType); ok {
+	if st, ok := t.(Type); ok {
 		return sliceType{
 			Type: reflect.SliceOf(st.Underlying()),
 			elem: st,
@@ -20,8 +21,8 @@ func (types *Types) SliceOf(t reflect.Type) reflect.Type {
 	return reflect.SliceOf(t)
 }
 
-// sliceType represents a composite slice type where the element is a Scriggo
-// type.
+// sliceType represents a composite slice type where the element is a
+// non-native type.
 type sliceType struct {
 	reflect.Type
 	elem reflect.Type
@@ -53,7 +54,7 @@ func (x sliceType) String() string {
 
 // Underlying implements the interface runtime.Wrapper.
 func (x sliceType) Underlying() reflect.Type {
-	assertNotScriggoType(x.Type)
+	assertNativeType(x.Type)
 	return x.Type
 }
 

--- a/compiler/types/struct.go
+++ b/compiler/types/struct.go
@@ -9,27 +9,27 @@ package types
 import "reflect"
 
 // StructOf behaves like reflect.StructOf except when at least one of the
-// fields has a Scriggo type; in such case a new Scriggo struct type is
+// fields has a non-native type; in such case a new non-native struct type is
 // created and returned as reflect.Type.
 func (types *Types) StructOf(fields []reflect.StructField) reflect.Type {
 
 	// baseFields contains all the fields with their Go type.
 	baseFields := make([]reflect.StructField, len(fields))
 
-	// scriggoFields contains the fields that are Scriggo fields, indexed by
-	// the index of the field.
+	// scriggoFields contains the fields that are non-native fields, indexed
+	// by the index of the field.
 	scriggoFields := map[int]reflect.StructField{}
 
 	for i, field := range fields {
 
-		// If field has a Scriggo type then it will be changed by the next
+		// If field has a non-native type then it will be changed by the next
 		// check.
 		baseFields[i] = field
 
 		// This field cannot be represented using the reflect: remove the
 		// information from the type and add that information to the
 		// structType.
-		if st, ok := field.Type.(ScriggoType); ok {
+		if st, ok := field.Type.(Type); ok {
 			baseFields[i].Type = st.Underlying()
 			scriggoField := field
 			scriggoField.Index = []int{i}
@@ -72,7 +72,7 @@ func (types *Types) addFields(fields map[int]reflect.StructField) *map[int]refle
 }
 
 // structType represents a composite struct type where at least one of the
-// fields has a Scriggo type.
+// fields has a non-native type.
 type structType struct {
 	reflect.Type
 	scriggoFields *map[int]reflect.StructField
@@ -142,7 +142,7 @@ func (x structType) String() string {
 
 // Underlying implements the interface runtime.Wrapper.
 func (x structType) Underlying() reflect.Type {
-	assertNotScriggoType(x.Type)
+	assertNativeType(x.Type)
 	return x.Type
 }
 

--- a/compiler/types/wrapper.go
+++ b/compiler/types/wrapper.go
@@ -12,7 +12,7 @@ import "reflect"
 // defined in this package. These two methods and the Underlying method
 // implement the runtime.Wrapper interface.
 
-func wrap(t ScriggoType, v reflect.Value) reflect.Value {
+func wrap(t Type, v reflect.Value) reflect.Value {
 	return reflect.ValueOf(emptyInterfaceProxy{
 		value: v,
 		sign:  t,
@@ -21,13 +21,13 @@ func wrap(t ScriggoType, v reflect.Value) reflect.Value {
 
 // TODO: currently unwrap always returns an empty interface wrapper. This will
 //  change when methods declaration will be implemented in Scriggo.
-func unwrap(x ScriggoType, v reflect.Value) (reflect.Value, bool) {
+func unwrap(x Type, v reflect.Value) (reflect.Value, bool) {
 	p, ok := v.Interface().(emptyInterfaceProxy)
 	// Not a proxy.
 	if !ok {
 		return reflect.Value{}, false
 	}
-	// v is a proxy but it has a different Scriggo type.
+	// v is a proxy but it has a different non-native type.
 	if p.sign != x {
 		return reflect.Value{}, false
 	}
@@ -38,5 +38,5 @@ func unwrap(x ScriggoType, v reflect.Value) (reflect.Value, bool) {
 // method set.
 type emptyInterfaceProxy struct {
 	value reflect.Value
-	sign  ScriggoType
+	sign  Type
 }

--- a/packages.go
+++ b/packages.go
@@ -12,7 +12,7 @@ import (
 	"github.com/open2b/scriggo/compiler"
 )
 
-// Package represents a predefined package.
+// Package represents a native package.
 type Package interface {
 
 	// Name returns the package's name.

--- a/runtime/env.go
+++ b/runtime/env.go
@@ -56,16 +56,16 @@ type Env interface {
 // types defined in a executed code.
 type Types interface {
 
-	// New is like reflect.New but if typ is a Scriggo type, the returned
+	// New is like reflect.New but if typ is a non-native type, the returned
 	// Value refers to the underling type of typ.
 	New(typ reflect.Type) reflect.Value
 
-	// TypeOf is like reflect.TypeOf but if i has a Scriggo type it returns
+	// TypeOf is like reflect.TypeOf but if i has a non-native type it returns
 	// its Scriggo reflect type instead of the reflect type of the proxy.
 	TypeOf(i interface{}) reflect.Type
 
-	// ValueOf is like reflect.ValueOf but if i has a Scriggo type it returns
-	// its underling value instead of the reflect value of the proxy.
+	// ValueOf is like reflect.ValueOf but if i has a non-native type it
+	// returns its underling value instead of the reflect value of the proxy.
 	ValueOf(i interface{}) reflect.Value
 }
 

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -138,7 +138,7 @@ func (vm *VM) convertPanic(msg interface{}) error {
 			break
 		}
 		fallthrough
-	case OpCallPredefined:
+	case OpCallNative:
 		switch msg := msg.(type) {
 		case runtimeError:
 			break

--- a/runtime/registers.go
+++ b/runtime/registers.go
@@ -233,7 +233,7 @@ func (vm *VM) generalIndirect(r int8) reflect.Value {
 	}
 	elem := v.Elem()
 	if elem.Kind() == reflect.Func {
-		return reflect.ValueOf(&callable{predefined: NewPredefinedFunction("", "", elem)})
+		return reflect.ValueOf(&callable{native: NewNativeFunction("", "", elem)})
 	}
 	return elem
 }
@@ -305,7 +305,7 @@ func (vm *VM) setFromReflectValue(r int8, v reflect.Value) registerType {
 		vm.setString(r, v.String())
 		return stringRegister
 	case reflect.Func:
-		c := &callable{predefined: NewPredefinedFunction("", "", v)}
+		c := &callable{native: NewNativeFunction("", "", v)}
 		vm.setGeneral(r, reflect.ValueOf(c))
 		return generalRegister
 	case reflect.Interface:

--- a/runtime/run.go
+++ b/runtime/run.go
@@ -57,7 +57,7 @@ func (vm *VM) runRecoverable() (err error) {
 
 func (vm *VM) run() (Addr, bool) {
 
-	var startPredefinedGoroutine bool
+	var startNativeGoroutine bool
 
 	var op Operation
 	var a, b, c int8
@@ -238,8 +238,8 @@ func (vm *VM) run() (Addr, bool) {
 			f := vm.general(a).Interface().(*callable)
 			if f.fn == nil {
 				off := vm.fn.Body[vm.pc]
-				vm.callPredefined(f.Predefined(), c, StackShift{int8(off.Op), off.A, off.B, off.C}, startPredefinedGoroutine)
-				startPredefinedGoroutine = false
+				vm.callNative(f.Native(), c, StackShift{int8(off.Op), off.A, off.B, off.C}, startNativeGoroutine)
+				startNativeGoroutine = false
 				vm.pc++
 			} else {
 				call := callFrame{cl: callable{fn: vm.fn, vars: vm.vars}, fp: vm.fp, pc: vm.pc + 1}
@@ -303,11 +303,11 @@ func (vm *VM) run() (Addr, bool) {
 			vm.vars = vm.env.globals
 			vm.calls = append(vm.calls, call)
 			vm.pc = 0
-		case OpCallPredefined:
-			fn := vm.fn.Predefined[uint8(a)]
+		case OpCallNative:
+			fn := vm.fn.NativeFunctions[uint8(a)]
 			off := vm.fn.Body[vm.pc]
-			vm.callPredefined(fn, c, StackShift{int8(off.Op), off.A, off.B, off.C}, startPredefinedGoroutine)
-			startPredefinedGoroutine = false
+			vm.callNative(fn, c, StackShift{int8(off.Op), off.A, off.B, off.C}, startNativeGoroutine)
+			startNativeGoroutine = false
 			vm.pc++
 
 		// Cap
@@ -583,9 +583,9 @@ func (vm *VM) run() (Addr, bool) {
 
 		// Go
 		case OpGo:
-			wasPredefined := vm.startGoroutine()
-			if wasPredefined {
-				startPredefinedGoroutine = true
+			wasNative := vm.startGoroutine()
+			if wasNative {
+				startNativeGoroutine = true
 			}
 
 		// Goto
@@ -936,7 +936,7 @@ func (vm *VM) run() (Addr, bool) {
 		case OpLoadFunc:
 			if a == 1 {
 				fn := callable{}
-				fn.predefined = vm.fn.Predefined[uint8(b)]
+				fn.native = vm.fn.NativeFunctions[uint8(b)]
 				vm.setGeneral(c, reflect.ValueOf(&fn))
 			} else {
 				fn := vm.fn.Functions[uint8(b)]

--- a/scriggo.go
+++ b/scriggo.go
@@ -60,7 +60,7 @@ func Build(src io.Reader, options *BuildOptions) (*Program, error) {
 }
 
 // Disassemble disassembles the package with the given path and returns its
-// assembly code. Predefined packages can not be disassembled.
+// assembly code. Native packages can not be disassembled.
 func (p *Program) Disassemble(pkgPath string) ([]byte, error) {
 	assemblies := compiler.Disassemble(p.fn, p.globals, 0)
 	asm, ok := assemblies[pkgPath]
@@ -150,7 +150,7 @@ func initPackageLevelVariables(globals []compiler.Global) []interface{} {
 // 	* 256 function literal declarations plus unique functions calls per
 // 	function
 // * 256 types available per function
-// * 256 unique predefined functions per function
+// * 256 unique native functions per function
 // * 16384 integer values per function
 // * 256 string values per function
 // * 16384 floating-point values per function

--- a/templates/template.go
+++ b/templates/template.go
@@ -116,13 +116,13 @@ type BuildOptions struct {
 	// accessible from the code in the template.
 	Globals Declarations
 
-	// Packages is a PackageLoader that makes precompiled packages available
+	// Packages is a PackageLoader that makes native packages available
 	// in the template through the 'import' statement.
 	//
-	// Note that an import statement refers to a precompiled package read from
+	// Note that an import statement refers to a native package read from
 	// Packages if its path has no extension.
 	//
-	//     {%  import  "my/package"   %}    Import a precompiled package.
+	//     {%  import  "my/package"   %}    Import a native package.
 	//     {%  import  "my/file.html  %}    Import a template file.
 	//
 	Packages scriggo.PackageLoader

--- a/templates/template_test.go
+++ b/templates/template_test.go
@@ -1415,7 +1415,7 @@ var templateMultiPageCases = map[string]struct {
 		expectedBuildErr: `cannot show sb1 (cannot show type []uint8 as text)`,
 	},
 
-	"Using the precompiled package 'fmt'": {
+	"Using the native package 'fmt'": {
 		sources: map[string]string{
 			"index.txt": `{% import "fmt" %}{{ fmt.Sprint(10, 20) }}`,
 		},
@@ -1423,7 +1423,7 @@ var templateMultiPageCases = map[string]struct {
 		expectedOut: "10 20",
 	},
 
-	"Using the precompiled package 'fmt' from a file that extends another file": {
+	"Using the native package 'fmt' from a file that extends another file": {
 		sources: map[string]string{
 			"index.txt":    `{% extends "extended.txt" %}{% import "fmt" %}{% macro M %}{{ fmt.Sprint(321, 11) }}{% end macro %}`,
 			"extended.txt": `{% show M() %}`,
@@ -1432,7 +1432,7 @@ var templateMultiPageCases = map[string]struct {
 		expectedOut: "321 11",
 	},
 
-	"Using the precompiled packages 'fmt' and 'math'": {
+	"Using the native packages 'fmt' and 'math'": {
 		sources: map[string]string{
 			"index.txt": `{% import "fmt" %}{% import m "math" %}{{ fmt.Sprint(-42, m.Abs(-42)) }}`,
 		},
@@ -1440,7 +1440,7 @@ var templateMultiPageCases = map[string]struct {
 		expectedOut: "-42 42",
 	},
 
-	"Importing the precompiled package 'fmt' with '.'": {
+	"Importing the native package 'fmt' with '.'": {
 		sources: map[string]string{
 			"index.txt": `{% import . "fmt" %}{{ Sprint(50, 70) }}`,
 		},
@@ -1448,7 +1448,7 @@ var templateMultiPageCases = map[string]struct {
 		expectedOut: "50 70",
 	},
 
-	"Trying to import a precompiled package that is not available in the loader": {
+	"Trying to import a native package that is not available in the loader": {
 		sources: map[string]string{
 			"index.txt": `{% import "mypackage" %}{{ mypackage.F() }}`,
 		},
@@ -1456,7 +1456,7 @@ var templateMultiPageCases = map[string]struct {
 		expectedBuildErr: "index.txt:1:11: syntax error: cannot find package \"mypackage\"",
 	},
 
-	"Trying to access a precompiled function 'SuperPrint' that is not available in the package 'fmt'": {
+	"Trying to access a native function 'SuperPrint' that is not available in the package 'fmt'": {
 		sources: map[string]string{
 			"index.txt": `{% import "fmt" %}{{ fmt.SuperPrint(42) }}`,
 		},
@@ -1464,7 +1464,7 @@ var templateMultiPageCases = map[string]struct {
 		expectedBuildErr: "index.txt:1:25: undefined: fmt.SuperPrint",
 	},
 
-	"Using the precompiled package 'fmt' without importing it returns an error": {
+	"Using the native package 'fmt' without importing it returns an error": {
 		sources: map[string]string{
 			"index.txt": `{{ fmt.Sprint(10, 20) }}`,
 		},
@@ -1599,7 +1599,7 @@ var templateMultiPageCases = map[string]struct {
 		expectedOut: "84\n\t\t\t84",
 	},
 
-	"Cannot access to unexported struct fields of a precompiled value (struct)": {
+	"Cannot access to unexported struct fields of a native value (struct)": {
 		sources: map[string]string{
 			"index.txt": `{{ s.foo }}`,
 		},
@@ -1612,7 +1612,7 @@ var templateMultiPageCases = map[string]struct {
 		expectedBuildErr: `s.foo undefined (cannot refer to unexported field or method foo)`,
 	},
 
-	"Cannot access to unexported struct fields of a precompiled value (*struct)": {
+	"Cannot access to unexported struct fields of a native value (*struct)": {
 		sources: map[string]string{
 			"index.txt": `{{ s.foo }}`,
 		},
@@ -2198,7 +2198,7 @@ var templateMultiPageCases = map[string]struct {
 		expectedBuildErr: `3:2: syntax error: unexpected text in imported file`,
 	},
 
-	"Show a Scriggo defined type value": {
+	"Show a non-native defined type value": {
 		sources: map[string]string{
 			"index.txt": `{% type Bool bool %}{{ Bool(true) }}`,
 		},
@@ -2574,7 +2574,7 @@ var templateMultiPageCases = map[string]struct {
 		expectedOut: "hello",
 	},
 
-	"Imported file that imported a precompiled package": {
+	"Imported file that imports a native package": {
 		sources: map[string]string{
 			"index.txt":    `{% import "imported.txt" %}{{ A }}, len is {{ len(A) }}`,
 			"imported.txt": `{% import "fmt" %}{% var A = fmt.Sprint(42) %}`,
@@ -2583,7 +2583,7 @@ var templateMultiPageCases = map[string]struct {
 		expectedOut: "42, len is 2",
 	},
 
-	"Importing and not using a precompiled package should not return error": {
+	"Importing and not using a native package should not return error": {
 		sources: map[string]string{
 			"index.txt": `{% import "fmt" %}that's ok`,
 		},

--- a/test/compare/cmd/Scriggofile
+++ b/test/compare/cmd/Scriggofile
@@ -1,4 +1,4 @@
-SET VARIABLE predefPkgs
+SET VARIABLE nativePackages
 
 IMPORT testpkg
 

--- a/test/compare/cmd/main.go
+++ b/test/compare/cmd/main.go
@@ -23,8 +23,8 @@ import (
 	"github.com/open2b/scriggo/templates"
 )
 
-//go:generate scriggo embed -v -o predefPkgs.go
-var predefPkgs scriggo.Packages
+//go:generate scriggo embed -v -o packages.go
+var nativePackages scriggo.Packages
 
 var globals = templates.Declarations{
 	"MainSum": func(a, b int) int { return a + b },
@@ -80,7 +80,7 @@ func main() {
 		var src io.Reader = os.Stdin
 		opts := &scriggo.BuildOptions{}
 		opts.DisallowGoStmt = *disallowGoStmt
-		opts.Packages = predefPkgs
+		opts.Packages = nativePackages
 		if cmd == "rundir" {
 			dir := dirLoader(flag.Arg(2))
 			main, err := dir.Load("main")
@@ -104,7 +104,7 @@ func main() {
 	case ".script":
 		opts := &scripts.BuildOptions{
 			DisallowGoStmt: *disallowGoStmt,
-			Packages: predefPkgs,
+			Packages: nativePackages,
 		}
 		script, err := scripts.Build(os.Stdin, opts)
 		if err != nil {
@@ -131,7 +131,7 @@ func main() {
 		}
 		opts := templates.BuildOptions{
 			Globals:           globals,
-			Packages:          predefPkgs,
+			Packages:          nativePackages,
 			MarkdownConverter: markdownConverter,
 		}
 		template, err := templates.Build(fsys, "index"+ext, &opts)

--- a/test/compare/testdata/github.com-golang-go/fixedbugs/issue33062.go
+++ b/test/compare/testdata/github.com-golang-go/fixedbugs/issue33062.go
@@ -1,4 +1,4 @@
-// skip : embedded struct fields are not supported for Scriggo types
+// skip : embedded struct fields are not supported for non-native types
 
 // run
 

--- a/test/compare/testdata/misc/ellipsis_call.go
+++ b/test/compare/testdata/misc/ellipsis_call.go
@@ -13,13 +13,13 @@ func f2(a string, b ...int) {
 }
 
 func main() {
-	// Functions defined in Scriggo.
+	// Non-native Functions.
 	f1([]int{}...)
 	f1([]int{1, 2, 3}...)
 	f2("a", []int{}...)
 	f2("b", []int{10, 20, 30}...)
 
-	// Predefined functions.
+	// Native functions.
 	s1 := []interface{}{1, 2, 3}
 	fmt.Println(s1...)
 	s2 := []interface{}{}

--- a/test/compare/testdata/misc/fun_lit.go
+++ b/test/compare/testdata/misc/fun_lit.go
@@ -6,7 +6,7 @@ import "fmt"
 
 func main() {
 
-	// Testing predefined function literals.
+	// Testing native function literals.
 	p := fmt.Println
 	p("a")
 	p("a", "b")
@@ -15,7 +15,7 @@ func main() {
 	p([]interface{}{1, 2, 3}...)
 	p([]interface{}(nil)...)
 
-	// Testing function literals defined in Scriggo.
+	// Testing non-native function literals.
 	f1 := func() {}
 	f1()
 

--- a/test/compare/testdata/misc/panic10.go
+++ b/test/compare/testdata/misc/panic10.go
@@ -1,6 +1,6 @@
 // paniccheck
 
-// Test a runtime error in a predefined function.
+// Test a runtime error in a native function.
 
 package main
 

--- a/test/compare/testdata/program_tests/pkg_var10.go
+++ b/test/compare/testdata/program_tests/pkg_var10.go
@@ -10,8 +10,8 @@ import (
 var Center = "msg"
 
 func main() {
-	predefinedC := testpkg.Center
-	fmt.Println(predefinedC)
+	nativeC := testpkg.Center
+	fmt.Println(nativeC)
 	c := Center
 	fmt.Println(c)
 }

--- a/test/program_test.go
+++ b/test/program_test.go
@@ -23,7 +23,7 @@ func (t TypeStruct) Method() {}
 // with usual tests as it would require an execution environment that would be
 // hard to reproduce without writing host code
 func TestIssue403(t *testing.T) {
-	t.Run("Method call on predefined variable", func(t *testing.T) {
+	t.Run("Method call on native variable", func(t *testing.T) {
 		packages := scriggo.CombinedLoader{
 			scriggo.Packages{
 				"pkg": scriggo.MapPackage{
@@ -51,7 +51,7 @@ func TestIssue403(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
-	t.Run("Method call on not-predefined variable", func(t *testing.T) {
+	t.Run("Method call on non-native variable", func(t *testing.T) {
 		packages := scriggo.CombinedLoader{
 			scriggo.Packages{
 				"pkg": scriggo.MapPackage{

--- a/test/script_test.go
+++ b/test/script_test.go
@@ -86,7 +86,7 @@ var scriptTests = map[string]struct {
 		},
 	},
 
-	// "Overwriting predefined main variable using init": {
+	// "Overwriting native main variable using init": {
 	// 	src: `
 	// 		Print(A)
 	// 	`,


### PR DESCRIPTION
This change uses the 'native' term to refer to packages, types,
variables, functions and values pre-compiled together with the Scriggo
compiler and runtime in an executable file. It uses 'non-native' to
refer to packages, types, variables, functions and values in a source
code compiled by Scriggo.

It also use 'source code', instead of 'Scriggo code', to refer to a
source code that is compiled by Scriggo.

To do this it changes comments, documentation and renames types,
functions, variables, constants and fields to use the new terms and
renames the 'CallPredefined' instruction to 'CallNative'.

Closes #381