### PR TITLE
compiler: implement 'import for' declaration

### DIFF
--- a/compiler/ast/ast.go
+++ b/compiler/ast/ast.go
@@ -812,21 +812,35 @@ func (n *Extends) String() string {
 
 // Import node represents a statement "import".
 type Import struct {
-	*Position             // position in the source.
-	Ident     *Identifier // name (including "." and "_") or nil.
-	Path      string      // path to import.
-	Tree      *Tree       // expanded tree of import.
+	*Position               // position in the source.
+	Ident     *Identifier   // name (including "." and "_") or nil.
+	Path      string        // path to import.
+	For       []*Identifier // exported identifiers that are enable for access.
+	Tree      *Tree         // expanded tree of import.
 }
 
-func NewImport(pos *Position, ident *Identifier, path string) *Import {
-	return &Import{Position: pos, Ident: ident, Path: path}
+func NewImport(pos *Position, ident *Identifier, path string, forIdents []*Identifier) *Import {
+	return &Import{Position: pos, Ident: ident, Path: path, For: forIdents}
 }
 
 func (n *Import) String() string {
-	if n.Ident == nil {
-		return fmt.Sprintf("import %v", strconv.Quote(n.Path))
+	var s strings.Builder
+	s.WriteString("import ")
+	if n.Ident != nil {
+		s.WriteString(n.Ident.Name)
+		s.WriteString(" ")
 	}
-	return fmt.Sprintf("import %v %v", n.Ident, strconv.Quote(n.Path))
+	s.WriteString(strconv.Quote(n.Path))
+	if n.For != nil {
+		s.WriteString("for ")
+		for i, ident := range n.For {
+			if i > 0 {
+				s.WriteString(", ")
+			}
+			s.WriteString(ident.Name)
+		}
+	}
+	return s.String()
 }
 
 // Comment node represents a statement {# ... #}.

--- a/compiler/ast/astutil/clone.go
+++ b/compiler/ast/astutil/clone.go
@@ -164,7 +164,14 @@ func CloneNode(node ast.Node) ast.Node {
 		if n.Ident != nil {
 			ident = ast.NewIdentifier(ClonePosition(n.Ident.Position), n.Ident.Name)
 		}
-		imp := ast.NewImport(ClonePosition(n.Position), ident, n.Path)
+		var forIdents []*ast.Identifier
+		if n.For != nil {
+			forIdents = make([]*ast.Identifier, len(n.For))
+			for i, ident := range n.For {
+				forIdents[i] = CloneExpression(ident).(*ast.Identifier)
+			}
+		}
+		imp := ast.NewImport(ClonePosition(n.Position), ident, n.Path, forIdents)
 		if n.Tree != nil {
 			imp.Tree = CloneTree(n.Tree)
 		}

--- a/compiler/checker_expressions.go
+++ b/compiler/checker_expressions.go
@@ -2410,7 +2410,7 @@ func (tc *typechecker) checkRender(render *ast.Render) *typeInfo {
 		// The same 'import' statement may be shared by different template
 		// files that 'render' the same file. This is the expected and intended
 		// behavior.
-		importt := ast.NewImport(nil, nil, "/"+render.Path)
+		importt := ast.NewImport(nil, nil, "/"+render.Path, nil)
 		importt.Tree = tree
 		importt.Tree.Nodes = []ast.Node{macroDecl}
 		stored.Macro = macroDecl

--- a/compiler/parser.go
+++ b/compiler/parser.go
@@ -1070,10 +1070,10 @@ LABEL:
 		if tok.typ == tokenLeftParenthesis && end != tokenEndStatement {
 			tok = p.next()
 			for tok.typ != tokenRightParenthesis {
-				node := p.parseImport(tok, end)
+				var node ast.Node
+				node, tok = p.parseImport(tok, end)
 				p.unexpanded = append(p.unexpanded, node)
 				p.addChild(node)
-				tok = p.next()
 				if tok.typ == tokenSemicolon {
 					tok = p.next()
 				} else if tok.typ != tokenRightParenthesis {
@@ -1086,10 +1086,10 @@ LABEL:
 			}
 			tok = p.next()
 		} else {
-			node := p.parseImport(tok, end)
+			var node ast.Node
+			node, tok = p.parseImport(tok, end)
 			p.unexpanded = append(p.unexpanded, node)
 			p.addChild(node)
-			tok = p.next()
 			tok = p.parseEnd(tok, tokenSemicolon, end)
 		}
 		p.cutSpacesToken = true
@@ -1615,8 +1615,8 @@ func lastImportOrExtends(nodes []ast.Node) bool {
 
 // parseImport parses an import declaration. tok if the first token of
 // ImportSpec and end is the argument passed to the parse method.
-// It returns the parsed node.
-func (p *parsing) parseImport(tok token, end tokenTyp) *ast.Import {
+// It returns the parsed node and the next not parsed token.
+func (p *parsing) parseImport(tok token, end tokenTyp) (*ast.Import, token)  {
 	pos := tok.pos
 	var ident *ast.Identifier
 	switch tok.typ {
@@ -1639,7 +1639,27 @@ func (p *parsing) parseImport(tok token, end tokenTyp) *ast.Import {
 		}
 	}
 	pos = pos.WithEnd(tok.pos.End)
-	return ast.NewImport(pos, ident, path)
+	tok = p.next()
+	var forIdents []*ast.Identifier
+	if end != tokenEOF && ident == nil && tok.typ == tokenFor {
+		for {
+			tok = p.next()
+			if tok.typ != tokenIdentifier {
+				panic(syntaxError(tok.pos, "unexpected %s, expecting name", tok))
+			}
+			name := string(tok.txt)
+			if r, _ := utf8.DecodeRuneInString(name); !unicode.Is(unicode.Lu, r) {
+				panic(syntaxError(tok.pos,"cannot enable access to unexported name %s", name))
+			}
+			forIdents = append(forIdents, ast.NewIdentifier(tok.pos, name))
+			pos = pos.WithEnd(tok.pos.End)
+			tok = p.next()
+			if tok.typ != tokenComma {
+				break
+			}
+		}
+	}
+	return ast.NewImport(pos, ident, path, forIdents), tok
 }
 
 // parseAssignment parses an assignment and returns an assignment or, if there

--- a/compiler/parser_program.go
+++ b/compiler/parser_program.go
@@ -20,7 +20,7 @@ func ParseProgram(packages PackageLoader) (*ast.Tree, error) {
 	trees := map[string]*ast.Tree{}
 	predefined := map[string]bool{}
 
-	main := ast.NewImport(nil, nil, "main")
+	main := ast.NewImport(nil, nil, "main", nil)
 
 	imports := []*ast.Import{main}
 

--- a/compiler/parser_test.go
+++ b/compiler/parser_test.go
@@ -711,13 +711,13 @@ var goContextTreeTests = []struct {
 		),
 	}, ast.FormatText)},
 	{"import \"p\"", ast.NewTree("", []ast.Node{
-		ast.NewImport(p(1, 8, 7, 9), nil, "p")}, ast.FormatText)},
+		ast.NewImport(p(1, 8, 7, 9), nil, "p", nil)}, ast.FormatText)},
 	{"import _ \"foo\"", ast.NewTree("", []ast.Node{
 		ast.NewImport(p(1, 8, 7, 13),
-			ast.NewIdentifier(p(1, 8, 7, 7), "_"), "foo")}, ast.FormatText)},
+			ast.NewIdentifier(p(1, 8, 7, 7), "_"), "foo", nil)}, ast.FormatText)},
 	{"import boo \"foo\"", ast.NewTree("", []ast.Node{
 		ast.NewImport(p(1, 8, 7, 15),
-			ast.NewIdentifier(p(1, 8, 7, 9), "boo"), "foo")}, ast.FormatText)},
+			ast.NewIdentifier(p(1, 8, 7, 9), "boo"), "foo", nil)}, ast.FormatText)},
 }
 
 var treeTests = []struct {
@@ -1376,6 +1376,14 @@ var treeTests = []struct {
 						ast.NewBasicLiteral(p(1, 13, 12, 12), ast.IntLiteral, "5"),
 					), nil, nil),
 			})}, ast.FormatHTML)},
+	{"{% import \"foo\" for A, B, C %}",
+		ast.NewTree("", []ast.Node{
+			ast.NewImport(p(1, 11, 10, 26), nil, "foo",
+				[]*ast.Identifier{
+					ast.NewIdentifier(p(1, 21, 20, 20), "A"),
+					ast.NewIdentifier(p(1, 24, 23, 23), "B"),
+					ast.NewIdentifier(p(1, 27, 26, 26), "C"),
+				})}, ast.FormatHTML)},
 }
 
 // TODO: this function is never called, because it is referenced in commented
@@ -1596,6 +1604,12 @@ func equals(n1, n2 ast.Node, p int) error {
 		}
 		if nn1.Path != nn2.Path {
 			return fmt.Errorf("unexpected name %q expecting %q", nn1.Path, nn2.Path)
+		}
+		for i, node := range nn1.For {
+			err := equals(node, nn2.For[i], p)
+			if err != nil {
+				return err
+			}
 		}
 
 	case *ast.Extends:

--- a/test/compare/testdata/syntax/import.html
+++ b/test/compare/testdata/syntax/import.html
@@ -1,0 +1,9 @@
+{# errorcheck #}
+
+{% import _ "foo" for A %}    // ERROR `unexpected for at end of statement`
+{% import . "foo" for A %}    // ERROR `unexpected for at end of statement`
+{% import boo "foo" for A %}  // ERROR `unexpected for at end of statement`
+{% import "foo" A %}          // ERROR `unexpected A at end of statement`
+{% import "foo" for A, %}     // ERROR `unexpected %}, expecting name`
+{% import "foo" for a %}      // ERROR `cannot enable access to unexported name a`
+{% import "foo" for _ %}      // ERROR `cannot enable access to unexported name _`


### PR DESCRIPTION
This change implements the 'import for' declaration

  import "foo" for A
  import "boo" for B, C, D

Closes #748