### PR TITLE
 compiler/emitter: support non local upvars in function literals 

### DIFF
--- a/test/compare/testdata/fixedbugs/issue759a.go
+++ b/test/compare/testdata/fixedbugs/issue759a.go
@@ -1,0 +1,13 @@
+// run
+
+package main
+
+var i int
+
+var V = func() {
+	_ = i
+}
+
+func main() {
+	V()
+}

--- a/test/compare/testdata/fixedbugs/issue759b.go
+++ b/test/compare/testdata/fixedbugs/issue759b.go
@@ -1,0 +1,13 @@
+// run
+
+package main
+
+var i int = 42
+
+var V = func() int {
+	return i
+}
+
+func main() {
+	println(V())
+}

--- a/test/compare/testdata/fixedbugs/issue759c.go
+++ b/test/compare/testdata/fixedbugs/issue759c.go
@@ -1,0 +1,13 @@
+// run
+
+package main
+
+var V = func() int {
+	return i
+}
+
+var i int = 42
+
+func main() {
+	println(V())
+}

--- a/test/compare/testdata/fixedbugs/issue759d.go
+++ b/test/compare/testdata/fixedbugs/issue759d.go
@@ -1,0 +1,15 @@
+// run
+
+package main
+
+var V = func() int {
+	return i + len(j)
+}
+
+var i int = 42
+
+var j string = "jjj"
+
+func main() {
+	println(V())
+}

--- a/test/compare/testdata/fixedbugs/issue759e.go
+++ b/test/compare/testdata/fixedbugs/issue759e.go
@@ -1,0 +1,15 @@
+// run
+
+package main
+
+var V = struct{ F func() int }{
+	func() int {
+		return i * 3
+	},
+}
+
+var i int = 42
+
+func main() {
+	println(V.F())
+}

--- a/test/compare/testdata/fixedbugs/issue759f.go
+++ b/test/compare/testdata/fixedbugs/issue759f.go
@@ -1,0 +1,13 @@
+// run
+
+package main
+
+var V = struct{ Field func() string }{
+	Field: F,
+}
+
+func F() string { return "F" }
+
+func main() {
+	println(V.Field())
+}

--- a/test/compare/testdata/github.com-golang-go/zerodivide.go
+++ b/test/compare/testdata/github.com-golang-go/zerodivide.go
@@ -1,4 +1,4 @@
-// skip : https://github.com/open2b/scriggo/issues/759
+// skip : investigate
 
 // run
 


### PR DESCRIPTION
Currently the method 'setFunctionVarRefs' only supports upvars that are
local variables. In the case that a function literal with upvars is
assigned to a package-level variable, the emitter calls
'setFunctionVarRefs' but such kind of upvars are not handled.

This commit fixes that.

See the issue #759 for more information.

Fix #759.