### PR TITLE
compiler: deprecate the dollar identifier

### DIFF
--- a/compiler/ast/astutil/dump_test.go
+++ b/compiler/ast/astutil/dump_test.go
@@ -43,7 +43,7 @@ func ExampleDump() {
 			if format == ast.FormatText {
 				tree, err = compiler.ParseScript(strings.NewReader(c), nil)
 			} else {
-				tree, _, err = compiler.ParseTemplateSource([]byte(c), format, false, false)
+				tree, _, err = compiler.ParseTemplateSource([]byte(c), format, false, false, false)
 			}
 			if err != nil {
 				panic(err)

--- a/compiler/ast/astutil/walk_test.go
+++ b/compiler/ast/astutil/walk_test.go
@@ -64,7 +64,7 @@ func TestWalk(t *testing.T) {
 	}
 
 	for _, c := range stringCases {
-		tree, _, err := compiler.ParseTemplateSource([]byte(c.input), ast.FormatHTML, false, false)
+		tree, _, err := compiler.ParseTemplateSource([]byte(c.input), ast.FormatHTML, false, false, false)
 		if err != nil {
 			panic(err)
 		}

--- a/compiler/checker_template_test.go
+++ b/compiler/checker_template_test.go
@@ -157,7 +157,7 @@ var checkerTemplateExprs = []struct {
 func TestCheckerTemplateExpressions(t *testing.T) {
 	options := checkerOptions{mod: templateMod, formatTypes: formatTypes, renderer: &renderer{}}
 	for _, expr := range checkerTemplateExprs {
-		var lex = scanTemplate([]byte("{{ "+expr.src+" }}"), ast.FormatText, false)
+		var lex = scanTemplate([]byte("{{ "+expr.src+" }}"), ast.FormatText, false, false)
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
@@ -237,7 +237,7 @@ var checkerTemplateExprErrors = []struct {
 func TestCheckerTemplateExpressionErrors(t *testing.T) {
 	options := checkerOptions{mod: templateMod, formatTypes: formatTypes}
 	for _, expr := range checkerTemplateExprErrors {
-		var lex = scanTemplate([]byte("{{ "+expr.src+" }}"), ast.FormatText, false)
+		var lex = scanTemplate([]byte("{{ "+expr.src+" }}"), ast.FormatText, false, false)
 		func() {
 			defer func() {
 				if r := recover(); r != nil {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -47,9 +47,17 @@ const (
 type Options struct {
 	DisallowGoStmt       bool
 	NoParseShortShowStmt bool
-	FormatTypes          map[ast.Format]reflect.Type
-	Globals              Declarations
-	Renderer             runtime.Renderer
+
+	// DollarIdentifier, when true, keeps the backward compatibility by
+	// supporting the dollar identifier.
+	//
+	// NOTE: the dollar identifier is deprecated and will be removed in a
+	// future version of Scriggo.
+	DollarIdentifier bool
+
+	FormatTypes map[ast.Format]reflect.Type
+	Globals     Declarations
+	Renderer    runtime.Renderer
 
 	// Packages loads Scriggo packages and precompiled packages.
 	//
@@ -162,7 +170,7 @@ func BuildTemplate(fsys fs.FS, name string, opts Options) (*Code, error) {
 
 	// Parse the source code.
 	var err error
-	tree, err = ParseTemplate(fsys, name, opts.Packages, opts.NoParseShortShowStmt)
+	tree, err = ParseTemplate(fsys, name, opts.Packages, opts.NoParseShortShowStmt, opts.DollarIdentifier)
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/lexer_test.go
+++ b/compiler/lexer_test.go
@@ -596,7 +596,7 @@ TYPES:
 	for source, types := range test {
 		var lex *lexer
 		if isTemplate {
-			lex = scanTemplate([]byte(source), format, false)
+			lex = scanTemplate([]byte(source), format, false, true)
 		} else {
 			lex = scanProgram([]byte(source))
 		}
@@ -686,7 +686,7 @@ func TestLexerMacroOrUsingContexts(t *testing.T) {
 CONTEXTS:
 	for source, contexts := range macroAndUsingContextTests {
 		text := []byte(source)
-		lex := scanTemplate(text, ast.FormatText, false)
+		lex := scanTemplate(text, ast.FormatText, false, false)
 		var i int
 		for tok := range lex.Tokens() {
 			if tok.typ == tokenEOF {
@@ -716,7 +716,7 @@ CONTEXTS:
 
 func TestPositions(t *testing.T) {
 	for _, test := range positionTests {
-		var lex = scanTemplate([]byte(test.src), ast.FormatHTML, false)
+		var lex = scanTemplate([]byte(test.src), ast.FormatHTML, false, false)
 		var i int
 		for tok := range lex.Tokens() {
 			if tok.typ == tokenEOF {
@@ -849,7 +849,7 @@ func TestLexRawContent(t *testing.T) {
 }
 
 func TestNoParseShow(t *testing.T) {
-	var lex = scanTemplate([]byte("a{{ v }}b"), ast.FormatHTML, true)
+	var lex = scanTemplate([]byte("a{{ v }}b"), ast.FormatHTML, true, false)
 	tokens := lex.Tokens()
 	if tok := <-tokens; tok.typ != tokenText {
 		t.Errorf("unexpected token %s, expecting text", tok)

--- a/compiler/parser.go
+++ b/compiler/parser.go
@@ -244,7 +244,7 @@ func parseSource(src []byte, script bool) (tree *ast.Tree, err error) {
 //
 // format can be Text, HTML, CSS, JavaScript, JSON and Markdown. imported
 // indicates whether it is imported.
-func ParseTemplateSource(src []byte, format ast.Format, imported, noParseShow bool) (tree *ast.Tree, unexpanded []ast.Node, err error) {
+func ParseTemplateSource(src []byte, format ast.Format, imported, noParseShow, dollarIdentifier bool) (tree *ast.Tree, unexpanded []ast.Node, err error) {
 
 	if format < ast.FormatText || format > ast.FormatMarkdown {
 		return nil, nil, errors.New("scriggo: invalid format")
@@ -253,7 +253,7 @@ func ParseTemplateSource(src []byte, format ast.Format, imported, noParseShow bo
 	tree = ast.NewTree("", nil, format)
 
 	var p = &parsing{
-		lex:        scanTemplate(src, format, noParseShow),
+		lex:        scanTemplate(src, format, noParseShow, dollarIdentifier),
 		format:     format,
 		imported:   imported,
 		ancestors:  []ast.Node{tree},

--- a/compiler/parser_cycle_test.go
+++ b/compiler/parser_cycle_test.go
@@ -171,7 +171,7 @@ var cycleTemplateTests = []struct {
 func TestCyclicTemplates(t *testing.T) {
 	for _, test := range cycleTemplateTests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := ParseTemplate(test.fsys, "index.html", nil, false)
+			_, err := ParseTemplate(test.fsys, "index.html", nil, false, false)
 			if err == nil {
 				t.Fatal("expecting cycle error, got no error")
 			}

--- a/compiler/parser_expressions_test.go
+++ b/compiler/parser_expressions_test.go
@@ -629,7 +629,7 @@ var exprTests = []struct {
 
 func TestExpressions(t *testing.T) {
 	for _, expr := range exprTests {
-		var lex = scanTemplate([]byte("{{"+expr.src+"}}"), ast.FormatText, false)
+		var lex = scanTemplate([]byte("{{"+expr.src+"}}"), ast.FormatText, false, true)
 		<-lex.Tokens()
 		func() {
 			defer func() {

--- a/compiler/parser_test.go
+++ b/compiler/parser_test.go
@@ -1515,7 +1515,7 @@ func TestShebang(t *testing.T) {
 
 func TestTrees(t *testing.T) {
 	for _, tree := range treeTests {
-		node, _, err := ParseTemplateSource([]byte(tree.src), ast.FormatHTML, false, false)
+		node, _, err := ParseTemplateSource([]byte(tree.src), ast.FormatHTML, false, false, true)
 		if err != nil {
 			t.Errorf("source: %q, %s\n", tree.src, err)
 			continue

--- a/templates/template.go
+++ b/templates/template.go
@@ -110,6 +110,13 @@ type BuildOptions struct {
 	NoParseShortShowStmt bool
 	TreeTransformer      func(*ast.Tree) error // if not nil transforms tree after parsing.
 
+	// DollarIdentifier, when true, keeps the backward compatibility by
+	// supporting the dollar identifier.
+	//
+	// NOTE: the dollar identifier is deprecated and will be removed in a
+	// future version of Scriggo.
+	DollarIdentifier bool
+
 	// MarkdownConverter converts a Markdown source code to HTML.
 	MarkdownConverter Converter
 
@@ -188,6 +195,7 @@ func Build(fsys fs.FS, name string, options *BuildOptions) (*Template, error) {
 		co.TreeTransformer = options.TreeTransformer
 		co.DisallowGoStmt = options.DisallowGoStmt
 		co.NoParseShortShowStmt = options.NoParseShortShowStmt
+		co.DollarIdentifier = options.DollarIdentifier
 		co.Packages = options.Packages
 		mdConverter = options.MarkdownConverter
 	}

--- a/templates/template_test.go
+++ b/templates/template_test.go
@@ -718,6 +718,7 @@ var templateMultiFileCases = map[string]struct {
 	entryPoint       string                 // default to "index.html"
 	packages         scriggo.PackageLoader  // default to nil
 	noParseShow      bool
+	dollarIdentifier bool // default to false
 }{
 
 	"Empty template": {
@@ -1741,11 +1742,19 @@ var templateMultiFileCases = map[string]struct {
 		expectedOut: "\n\t\t\t\t\t\t\t\t\t\t\n\t\t\t\t\t\tm2\n\n\t\t\t",
 	},
 
+	"Dollar identifier - No longer supported": {
+		sources: map[string]string{
+			"index.txt": `{% var _ interface{} = $notExisting %}{{ $notExisting2 == nil }}`,
+		},
+		expectedBuildErr: `index.txt:1:24: syntax error: invalid character U+0024 '$'`,
+	},
+
 	"Dollar identifier - Referencing to a global variable that does not exist": {
 		sources: map[string]string{
 			"index.txt": `{% var _ interface{} = $notExisting %}{{ $notExisting2 == nil }}`,
 		},
-		expectedOut: "true",
+		dollarIdentifier: true,
+		expectedOut:      "true",
 	},
 
 	"Dollar identifier - Referencing to a global variable that exists": {
@@ -1758,7 +1767,8 @@ var templateMultiFileCases = map[string]struct {
 				"forthyTwo": &([]int8{42}[0]),
 			},
 		},
-		expectedOut: "42",
+		dollarIdentifier: true,
+		expectedOut:      "42",
 	},
 
 	"Dollar identifier - Type assertion on a global variable that exists (1)": {
@@ -1771,7 +1781,8 @@ var templateMultiFileCases = map[string]struct {
 				"forthyThree": &([]int{43}[0]),
 			},
 		},
-		expectedOut: "43",
+		dollarIdentifier: true,
+		expectedOut:      "43",
 	},
 
 	"Dollar identifier - Type assertion on a global variable that exists (2)": {
@@ -1784,13 +1795,15 @@ var templateMultiFileCases = map[string]struct {
 				"forthyThree": &([]int{42}[0]),
 			},
 		},
-		expectedOut: "1344true",
+		dollarIdentifier: true,
+		expectedOut:      "1344true",
 	},
 
 	"Dollar identifier - Cannot use an type": {
 		sources: map[string]string{
 			"index.txt": `{% _ = $int %}`,
 		},
+		dollarIdentifier: true,
 		expectedBuildErr: `unexpected type in dollar identifier`,
 	},
 
@@ -1798,6 +1811,7 @@ var templateMultiFileCases = map[string]struct {
 		sources: map[string]string{
 			"index.txt": `{% _ = $println %}`,
 		},
+		dollarIdentifier: true,
 		expectedBuildErr: `use of builtin println not in function call`,
 	},
 
@@ -1805,6 +1819,7 @@ var templateMultiFileCases = map[string]struct {
 		sources: map[string]string{
 			"index.txt": `{% var local = 10 %}{% _ = $local %}`,
 		},
+		dollarIdentifier: true,
 		expectedBuildErr: `use of local identifier within dollar identifier`,
 	},
 
@@ -1818,6 +1833,7 @@ var templateMultiFileCases = map[string]struct {
 				"forthyTwo": &([]int8{42}[0]),
 			},
 		},
+		dollarIdentifier: true,
 		expectedBuildErr: `cannot take the address of $fortyTwo`,
 	},
 
@@ -1825,6 +1841,7 @@ var templateMultiFileCases = map[string]struct {
 		sources: map[string]string{
 			"index.txt": `{% _ = &($notExisting) %}`,
 		},
+		dollarIdentifier: true,
 		expectedBuildErr: `cannot take the address of $notExisting`,
 	},
 
@@ -1838,6 +1855,7 @@ var templateMultiFileCases = map[string]struct {
 				"forthyTwo": &([]int8{42}[0]),
 			},
 		},
+		dollarIdentifier: true,
 		expectedBuildErr: `cannot assign to $fortyTwo`,
 	},
 
@@ -1845,6 +1863,7 @@ var templateMultiFileCases = map[string]struct {
 		sources: map[string]string{
 			"index.txt": `{% $notExisting = 43 %}`,
 		},
+		dollarIdentifier: true,
 		expectedBuildErr: `cannot assign to $notExisting`,
 	},
 
@@ -1858,6 +1877,7 @@ var templateMultiFileCases = map[string]struct {
 				"constant": 42,
 			},
 		},
+		dollarIdentifier: true,
 		expectedBuildErr: `const initializer $constant is not a constant`,
 	},
 
@@ -1905,6 +1925,7 @@ var templateMultiFileCases = map[string]struct {
 			"index.txt":    `{% import "imported.txt" %}`,
 			"imported.txt": `{% var X = 10 %}{% var _ = $X %}`,
 		},
+		dollarIdentifier: true,
 		expectedBuildErr: `use of top-level identifier within dollar identifier`,
 	},
 
@@ -1913,6 +1934,7 @@ var templateMultiFileCases = map[string]struct {
 			"index.txt":    `{% extends "extended.txt" %}{% var X = 10 %}{% var _ = $X %}`,
 			"extended.txt": ``,
 		},
+		dollarIdentifier: true,
 		expectedBuildErr: `use of top-level identifier within dollar identifier`,
 	},
 
@@ -1921,6 +1943,7 @@ var templateMultiFileCases = map[string]struct {
 			"index.txt":    `{% import "imported.txt" %}`,
 			"imported.txt": `{% var x = $global %}`,
 		},
+		dollarIdentifier: true,
 	},
 
 	"https://github.com/open2b/scriggo/issues/680 - Extends": {
@@ -1928,6 +1951,7 @@ var templateMultiFileCases = map[string]struct {
 			"index.txt":    `{% extends "extended.txt" %}{% var x = $global %}`,
 			"extended.txt": ``,
 		},
+		dollarIdentifier: true,
 	},
 
 	"Panic after importing file that declares a variable in general register (1)": {
@@ -1958,7 +1982,8 @@ var templateMultiFileCases = map[string]struct {
 				"global": (*int)(nil),
 			},
 		},
-		expectedOut: "text",
+		dollarIdentifier: true,
+		expectedOut:      "text",
 	},
 
 	"https://github.com/open2b/scriggo/issues/686 (2)": {
@@ -1972,7 +1997,8 @@ var templateMultiFileCases = map[string]struct {
 				"global": (*int)(nil),
 			},
 		},
-		expectedOut: "text",
+		dollarIdentifier: true,
+		expectedOut:      "text",
 	},
 
 	"https://github.com/open2b/scriggo/issues/687": {
@@ -2001,7 +2027,8 @@ var templateMultiFileCases = map[string]struct {
 				}{},
 			},
 		},
-		expectedOut: "\n\t\t\t\t<head>\n\t\t\t\t<script>....\n\t\t\t\t\"\"\t\t\n\t\t\t\t\"\"\t\t\n\t\t\t\tfef",
+		expectedOut:      "\n\t\t\t\t<head>\n\t\t\t\t<script>....\n\t\t\t\t\"\"\t\t\n\t\t\t\t\"\"\t\t\n\t\t\t\tfef",
+		dollarIdentifier: true,
 	},
 
 	"https://github.com/open2b/scriggo/issues/655": {
@@ -2121,6 +2148,7 @@ var templateMultiFileCases = map[string]struct {
 			%%}{% var x = $global %}`,
 			"extended.txt": ``,
 		},
+		dollarIdentifier: true,
 	},
 
 	"Multi line statements #2": {
@@ -2132,7 +2160,8 @@ var templateMultiFileCases = map[string]struct {
 				var a []int
 			%%}`,
 		},
-		expectedOut: "beforeafter",
+		dollarIdentifier: true,
+		expectedOut:      "beforeafter",
 	},
 
 	"Multi line statements #3": {
@@ -2140,6 +2169,7 @@ var templateMultiFileCases = map[string]struct {
 			"index.txt":    `{%% import "imported.txt" %%}`,
 			"imported.txt": `{% var x = $global %}`,
 		},
+		dollarIdentifier: true,
 	},
 
 	"Multi line statements #4": {
@@ -2147,6 +2177,7 @@ var templateMultiFileCases = map[string]struct {
 			"index.txt":    `{% import "imported.txt" %}`,
 			"imported.txt": `{%% var x = $global %%}`,
 		},
+		dollarIdentifier: true,
 	},
 
 	"Multiline statements #5": {
@@ -3657,6 +3688,7 @@ func TestMultiFileTemplate(t *testing.T) {
 				Packages:             cas.packages,
 				MarkdownConverter:    markdownConverter,
 				NoParseShortShowStmt: cas.noParseShow,
+				DollarIdentifier:     cas.dollarIdentifier,
 			}
 			template, err := Build(fsys, entryPoint, opts)
 			switch {


### PR DESCRIPTION
The dollar identifier can still be used by explicitly setting a build
option.

See #774.