### PR TITLE
compiler/checker: fix imported and not used error enabling package cache

### DIFF
--- a/compiler/checker_package.go
+++ b/compiler/checker_package.go
@@ -517,13 +517,10 @@ varsLoop:
 // checkPackage type checks a package.
 func checkPackage(compilation *compilation, pkg *ast.Package, path string, packages PackageLoader, opts checkerOptions) (err error) {
 
-	// TODO: This cache has been disabled as a workaround to the issues #641 and
-	// #624. We should find a better solution in the future.
-	//
-	// // If the package has already been checked just return.
-	// if _, ok := compilation.pkgInfos[path]; ok {
-	// 	return
-	// }
+	// If the package has already been checked just return.
+	if _, ok := compilation.pkgInfos[path]; ok {
+		return
+	}
 
 	defer func() {
 		if r := recover(); r != nil {

--- a/test/compare/testdata/program_imports/many_calls_to_init.go
+++ b/test/compare/testdata/program_imports/many_calls_to_init.go
@@ -1,3 +1,1 @@
-// skip : returns a false positive 'imported but not used'. See https://github.com/open2b/scriggo/issues/662.
-
 // rundir


### PR DESCRIPTION
This change enable the package cache that was disable by commit
6763a0d923e3b47b52b69a5274c887f432f9ddfb.

In this way it fixes the issue #662 about the "imported and not used"
error which occurs when a package is imported two or more times.

The issue #662 is due to multiple type checks of packages. In the second
type check the identifiers in a function body are not checked because
they have already been checked in the first type check and consequently
they have not been set as used in scopes.

Fixes #662