### PR TITLE
compiler/types: revise 'AssignableTo', 'ConvertibleTo' and 'Implements'

### DIFF
--- a/compiler/checker_expressions.go
+++ b/compiler/checker_expressions.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/open2b/scriggo/compiler/ast"
+	"github.com/open2b/scriggo/compiler/types"
 	"github.com/open2b/scriggo/runtime"
 )
 
@@ -858,7 +859,7 @@ func (tc *typechecker) typeof(expr ast.Expression, typeExpected bool) *typeInfo 
 			panic(tc.errorf(expr, "invalid type assertion: %v (non-interface type %s on left)", expr, t))
 		}
 		typ := tc.checkType(expr.Type)
-		if typ.Type.Kind() != reflect.Interface && !tc.types.Implements(typ.Type, t.Type) {
+		if typ.Type.Kind() != reflect.Interface && !types.Implements(typ.Type, t.Type) {
 			panic(tc.errorf(expr, "%s", tc.errTypeAssertion(typ.Type, t.Type)))
 		}
 		return &typeInfo{
@@ -1736,7 +1737,7 @@ func (tc *typechecker) checkCallExpression(expr *ast.Call) []*typeInfo {
 			if c == nil {
 				c = tc.checkExpr(arg)
 			}
-			if callIsVariadic && i == len(args)-1 && (c.Nil() || tc.types.AssignableTo(c.Type, t.Type.In(numIn-1))) {
+			if callIsVariadic && i == len(args)-1 && (c.Nil() || types.AssignableTo(c.Type, t.Type.In(numIn-1))) {
 				have += "..." + t.Type.In(numIn-1).Elem().String()
 			} else if c.Nil() {
 				have += "nil"
@@ -1889,7 +1890,7 @@ func (tc *typechecker) checkExplicitConversion(expr *ast.Call) *typeInfo {
 					err = errTypeConversion
 				}
 			case t.Type.Kind() == reflect.Interface:
-				if !tc.types.Implements(arg.Type, t.Type) {
+				if !types.Implements(arg.Type, t.Type) {
 					err = errTypeConversion
 				}
 			default:
@@ -1902,7 +1903,7 @@ func (tc *typechecker) checkExplicitConversion(expr *ast.Call) *typeInfo {
 	case arg.Untyped():
 		_, err = tc.convert(arg, expr.Args[0], t.Type)
 	default:
-		if !tc.types.ConvertibleTo(arg.Type, t.Type) {
+		if !types.ConvertibleTo(arg.Type, t.Type) {
 			err = errTypeConversion
 		}
 	}

--- a/compiler/checker_statements.go
+++ b/compiler/checker_statements.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 
 	"github.com/open2b/scriggo/compiler/ast"
+	"github.com/open2b/scriggo/compiler/types"
 	"github.com/open2b/scriggo/runtime"
 )
 
@@ -640,7 +641,7 @@ nodesLoop:
 			if len(node.Expressions) == 1 {
 				if call, ok := node.Expressions[0].(*ast.Call); ok {
 					tis := tc.checkCallExpression(call)
-					if len(tis) == 2 && tc.types.Implements(tis[1].Type, errorType) {
+					if len(tis) == 2 && types.Implements(tis[1].Type, errorType) {
 						// Change the tree:
 						//
 						//     from: {{ f(..) }}

--- a/compiler/checker_util.go
+++ b/compiler/checker_util.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/open2b/scriggo/compiler/ast"
+	"github.com/open2b/scriggo/compiler/types"
 	"github.com/open2b/scriggo/runtime"
 )
 
@@ -369,16 +370,7 @@ func (tc *typechecker) isAssignableTo(x *typeInfo, expr ast.Expression, t reflec
 		}
 		return err
 	}
-	if x.Type == t {
-		return nil
-	}
-	if t.Kind() == reflect.Interface {
-		if !tc.types.Implements(x.Type, t) {
-			return newInvalidTypeInAssignment(x, expr, t)
-		}
-		return nil
-	}
-	if !tc.types.AssignableTo(x.Type, t) {
+	if !types.AssignableTo(x.Type, t) {
 		return newInvalidTypeInAssignment(x, expr, t)
 	}
 	return nil

--- a/compiler/types/array.go
+++ b/compiler/types/array.go
@@ -31,20 +31,20 @@ type arrayType struct {
 	elem         reflect.Type // array element, always a Scriggo type
 }
 
-// AssignableTo is equivalent to reflect's AssignableTo.
-func (x arrayType) AssignableTo(u reflect.Type) bool {
-	return x == u
+func (x arrayType) AssignableTo(y reflect.Type) bool {
+	return AssignableTo(x, y)
+}
+
+func (x arrayType) ConvertibleTo(y reflect.Type) bool {
+	return ConvertibleTo(x, y)
 }
 
 func (x arrayType) Elem() reflect.Type {
 	return x.elem
 }
 
-func (x arrayType) Implements(u reflect.Type) bool {
-	if u.Kind() != reflect.Interface {
-		panic("expected reflect.Interface")
-	}
-	return u.NumMethod() == 0
+func (x arrayType) Implements(y reflect.Type) bool {
+	return Implements(x, y)
 }
 
 func (x arrayType) Name() string {

--- a/compiler/types/chan.go
+++ b/compiler/types/chan.go
@@ -27,20 +27,20 @@ type chanType struct {
 	elem         reflect.Type // channel element, always a Scriggo type
 }
 
-// AssignableTo is equivalent to reflect's AssignableTo.
-func (x chanType) AssignableTo(u reflect.Type) bool {
-	return x == u
+func (x chanType) AssignableTo(y reflect.Type) bool {
+	return AssignableTo(x, y)
+}
+
+func (x chanType) ConvertibleTo(y reflect.Type) bool {
+	return ConvertibleTo(x, y)
 }
 
 func (x chanType) Elem() reflect.Type {
 	return x.elem
 }
 
-func (x chanType) Implements(u reflect.Type) bool {
-	if u.Kind() != reflect.Interface {
-		panic("expected reflect.Interface")
-	}
-	return u.NumMethod() == 0
+func (x chanType) Implements(y reflect.Type) bool {
+	return Implements(x, y)
 }
 
 func (x chanType) Name() string {

--- a/compiler/types/defined.go
+++ b/compiler/types/defined.go
@@ -36,34 +36,16 @@ func (x definedType) Name() string {
 	return x.name
 }
 
-// AssignableTo is equivalent to reflect's AssignableTo.
-func (x definedType) AssignableTo(u reflect.Type) bool {
-
-	// Both x and u are Scriggo defined types: x is assignable to u only if
-	// they are the same type.
-	if T, ok := u.(definedType); ok {
-		return x == T
-	}
-
-	// x is a Scriggo defined type and u is not a defined type: x is
-	// assignable to u only if the underlying type of x is assignable to u.
-	if !isDefinedType(u) {
-		return x.Type.AssignableTo(u)
-	}
-
-	// x is a Scriggo defined type and u is a Go defined type: assignment is
-	// always impossible.
-	return false
-
+func (x definedType) AssignableTo(y reflect.Type) bool {
+	return AssignableTo(x, y)
 }
 
-func (x definedType) Implements(u reflect.Type) bool {
-	if u.Kind() != reflect.Interface {
-		panic("expected reflect.Interface")
-	}
-	// TODO: currently methods definition is not supported, so every defined
-	// type implements only the empty interface.
-	return u.NumMethod() == 0
+func (x definedType) ConvertibleTo(y reflect.Type) bool {
+	return ConvertibleTo(x, y)
+}
+
+func (x definedType) Implements(y reflect.Type) bool {
+	return Implements(x, y)
 }
 
 func (x definedType) MethodByName(string) (reflect.Method, bool) {

--- a/compiler/types/func.go
+++ b/compiler/types/func.go
@@ -110,16 +110,16 @@ type funcType struct {
 	in, out *[]reflect.Type
 }
 
-// AssignableTo is equivalent to reflect's AssignableTo.
-func (x funcType) AssignableTo(u reflect.Type) bool {
-	return x == u
+func (x funcType) AssignableTo(y reflect.Type) bool {
+	return AssignableTo(x, y)
 }
 
-func (x funcType) Implements(u reflect.Type) bool {
-	if u.Kind() != reflect.Interface {
-		panic("expected reflect.Interface")
-	}
-	return u.NumMethod() == 0
+func (x funcType) ConvertibleTo(y reflect.Type) bool {
+	return ConvertibleTo(x, y)
+}
+
+func (x funcType) Implements(y reflect.Type) bool {
+	return Implements(x, y)
 }
 
 func (x funcType) In(i int) reflect.Type {

--- a/compiler/types/map.go
+++ b/compiler/types/map.go
@@ -43,9 +43,12 @@ type mapType struct {
 	key, elem reflect.Type
 }
 
-// AssignableTo is equivalent to reflect's AssignableTo.
-func (x mapType) AssignableTo(u reflect.Type) bool {
-	return x == u
+func (x mapType) AssignableTo(y reflect.Type) bool {
+	return AssignableTo(x, y)
+}
+
+func (x mapType) ConvertibleTo(y reflect.Type) bool {
+	return ConvertibleTo(x, y)
 }
 
 func (x mapType) Elem() reflect.Type {
@@ -55,11 +58,8 @@ func (x mapType) Elem() reflect.Type {
 	return x.Type.Elem()
 }
 
-func (x mapType) Implements(u reflect.Type) bool {
-	if u.Kind() != reflect.Interface {
-		panic("expected reflect.Interface")
-	}
-	return u.NumMethod() == 0
+func (x mapType) Implements(y reflect.Type) bool {
+	return Implements(x, y)
 }
 
 func (x mapType) Name() string {

--- a/compiler/types/ptr.go
+++ b/compiler/types/ptr.go
@@ -27,20 +27,20 @@ type ptrType struct {
 	elem reflect.Type // Cannot be nil.
 }
 
-// AssignableTo is equivalent to reflect's AssignableTo.
-func (x ptrType) AssignableTo(u reflect.Type) bool {
-	return x == u
+func (x ptrType) AssignableTo(y reflect.Type) bool {
+	return AssignableTo(x, y)
+}
+
+func (x ptrType) ConvertibleTo(y reflect.Type) bool {
+	return ConvertibleTo(x, y)
 }
 
 func (x ptrType) Elem() reflect.Type {
 	return x.elem
 }
 
-func (x ptrType) Implements(u reflect.Type) bool {
-	if u.Kind() != reflect.Interface {
-		panic("expected reflect.Interface")
-	}
-	return u.NumMethod() == 0
+func (x ptrType) Implements(y reflect.Type) bool {
+	return Implements(x, y)
 }
 
 func (x ptrType) Name() string {

--- a/compiler/types/slice.go
+++ b/compiler/types/slice.go
@@ -27,20 +27,20 @@ type sliceType struct {
 	elem reflect.Type
 }
 
-// AssignableTo is equivalent to reflect's AssignableTo.
-func (x sliceType) AssignableTo(u reflect.Type) bool {
-	return x == u
+func (x sliceType) AssignableTo(y reflect.Type) bool {
+	return AssignableTo(x, y)
+}
+
+func (x sliceType) ConvertibleTo(y reflect.Type) bool {
+	return ConvertibleTo(x, y)
 }
 
 func (x sliceType) Elem() reflect.Type {
 	return x.elem
 }
 
-func (x sliceType) Implements(u reflect.Type) bool {
-	if u.Kind() != reflect.Interface {
-		panic("expected reflect.Interface")
-	}
-	return u.NumMethod() == 0
+func (x sliceType) Implements(y reflect.Type) bool {
+	return Implements(x, y)
 }
 
 func (x sliceType) Name() string {

--- a/compiler/types/struct.go
+++ b/compiler/types/struct.go
@@ -78,9 +78,12 @@ type structType struct {
 	scriggoFields *map[int]reflect.StructField
 }
 
-// AssignableTo is equivalent to reflect's AssignableTo.
-func (x structType) AssignableTo(u reflect.Type) bool {
-	return x == u
+func (x structType) AssignableTo(y reflect.Type) bool {
+	return AssignableTo(x, y)
+}
+
+func (x structType) ConvertibleTo(y reflect.Type) bool {
+	return ConvertibleTo(x, y)
 }
 
 func (x structType) Field(i int) reflect.StructField {
@@ -107,11 +110,8 @@ func (x structType) FieldByNameFunc(match func(string) bool) (reflect.StructFiel
 	panic("TODO: not implemented") // TODO(Gianluca): to implement.
 }
 
-func (x structType) Implements(u reflect.Type) bool {
-	if u.Kind() != reflect.Interface {
-		panic("expected reflect.Interface")
-	}
-	return u.NumMethod() == 0
+func (x structType) Implements(y reflect.Type) bool {
+	return Implements(x, y)
 }
 
 func (x structType) Name() string {

--- a/compiler/types/types.go
+++ b/compiler/types/types.go
@@ -42,11 +42,6 @@ type ScriggoType interface {
 	Underlying() reflect.Type
 }
 
-// isDefinedType reports whether t is a defined type.
-func isDefinedType(t reflect.Type) bool {
-	return t.Name() != ""
-}
-
 // New behaves like reflect.New except when typ is a Scriggo type; in such
 // case it returns an instance of the underlying type created with a
 // reflect.New call.
@@ -66,72 +61,238 @@ func (types *Types) Zero(t reflect.Type) reflect.Value {
 	return reflect.Zero(t)
 }
 
-// AssignableTo is equivalent to reflect's AssignableTo.
-func (types *Types) AssignableTo(x, u reflect.Type) bool {
+// AssignableTo reports whether a value of type x is assignable to type y.
+func AssignableTo(x, y reflect.Type) bool {
 
-	typ, isScriggoType := u.(ScriggoType)
-
-	// u is not a Scriggo type (is implemented by the reflect package), so
-	// it's safe to call the reflect method AssignableTo with u as argument.
-	if !isScriggoType {
-		return x.AssignableTo(u)
-	}
-
-	// typ is a Scriggo type.
-	// x can be both a Scriggo type or a gc compiled type.
-
-	// The type is the same so x is assignable to typ.
-	if x == typ {
+	// x and y types are identical.
+	if x == y {
 		return true
 	}
 
-	xIsDefined := isDefinedType(x)
-	tIsDefined := isDefinedType(typ)
+	// If y is an interface type, x must implement y.
+	k := y.Kind()
+	if k == reflect.Interface {
+		return Implements(x, y)
+	}
 
-	// x and typ are both defined types but they are not the same: not
-	// assignable.
-	if xIsDefined && tIsDefined {
+	// x and y have different kind.
+	if x.Kind() != k {
 		return false
 	}
 
-	// Just one is defined.
-	if xIsDefined != tIsDefined {
-		return x.AssignableTo(typ.Underlying())
+	// x and y are both defined types.
+	if x.Name() != "" && y.Name() != "" {
+		return false
 	}
 
-	// TODO: any other cases missing? Or it's ok to return 'false' here?
+	// x and y are channel types, x is bidirectional, and they have identical element types.
+	if k == reflect.Chan && x.ChanDir() == reflect.BothDir && x.Elem() == y.Elem() {
+		return true
+	}
+
+	// x and y must have identical underlying types.
+	return identical(x, y, true, false)
+}
+
+// ConvertibleTo reports whether a value of type x is convertible to type y.
+func ConvertibleTo(x, y reflect.Type) bool {
+
+	// x and y types are identical.
+	if x == y {
+		return true
+	}
+
+	xk := x.Kind()
+	yk := y.Kind()
+
+	// y is a string type and x is an integer type or a slice of bytes or runes.
+	if yk == reflect.String {
+		if reflect.Int <= xk && xk <= reflect.Uintptr {
+			return true
+		}
+		if xk == reflect.Slice {
+			if e := x.Elem(); e.PkgPath() == "" {
+				if k := e.Kind(); k == reflect.Uint8 || k == reflect.Int32 {
+					return true
+				}
+			}
+		}
+	}
+
+	// x and y are integer or floating point types.
+	if reflect.Int <= xk && xk <= reflect.Float64 && reflect.Int <= yk && yk <= reflect.Float64 {
+		return true
+	}
+
+	// x and y are complex types.
+	if (xk == reflect.Complex128 || xk == reflect.Complex64) && (yk == reflect.Complex128 || yk == reflect.Complex64) {
+		return true
+	}
+
+	// x is a string type and y is a slice of bytes or runes.
+	if xk == reflect.String && yk == reflect.Slice {
+		if e := y.Elem(); e.PkgPath() == "" {
+			if k := e.Kind(); k == reflect.Uint8 || k == reflect.Int32 {
+				return true
+			}
+		}
+	}
+
+	// x and y are channel types, are not both defined, x is bidirectional, and they have identical element types.
+	if xk == reflect.Chan && yk == reflect.Chan && x.ChanDir() == reflect.BothDir &&
+		x.Elem() == y.Elem() && (x.Name() == "" || y.Name() == "") {
+		return true
+	}
+
+	// x is a slice, y is a pointer to array type, and the slice and array have the same element types.
+	if xk == reflect.Slice && yk == reflect.Ptr {
+		if e := y.Elem(); e.Kind() == reflect.Array && e.Elem() == x.Elem() {
+			return true
+		}
+	}
+
+	// If y is an interface type, x must implement y.
+	if yk == reflect.Interface {
+		return Implements(x, y)
+	}
+
+	// x and y have identical underlying types, ignoring struct tags.
+	if identical(x, y, true, true) {
+		return true
+	}
+
+	// x and y are not defined pointer types, and have identical underlying types, ignoring struct tags.
+	if xk == reflect.Ptr && yk == reflect.Ptr &&
+		x.Name() == "" && y.Name() == "" && identical(x.Elem(), y.Elem(), true, true) {
+		return true
+	}
+
 	return false
 }
 
-// ConvertibleTo is equivalent to reflect's ConvertibleTo.
-func (types *Types) ConvertibleTo(x, u reflect.Type) bool {
-	if x, ok := x.(ScriggoType); ok {
-		return types.ConvertibleTo(x.Underlying(), u)
+// Implements reports whether x implements the interface type y.
+func Implements(x, y reflect.Type) bool {
+	if _, ok := x.(ScriggoType); ok {
+		return y.NumMethod() == 0
 	}
-	if u, ok := u.(ScriggoType); ok {
-		return types.ConvertibleTo(x, u.Underlying())
+	if _, ok := y.(ScriggoType); ok {
+		return true
 	}
-	return x.ConvertibleTo(u) // x is implemented by the reflect package.
+	// If y has unexported methods, and x is not an interface type, it is not possible to check
+	// if x implements y using the x.NumMethod and x.Method methods, because they do not return
+	// the unexported methods of x. Therefore, the x.Implements method is used instead.
+	return x.Implements(y)
 }
 
-// Implements behaves like x.Implements(u) except when one of x or u is a
-// Scriggo type.
-func (types *Types) Implements(x, u reflect.Type) bool {
+// identical reports whether the types x and y, or their underlying types if
+// underlying is true, are identical. If skipTags is true, the tags are
+// ignored.
+func identical(x, y reflect.Type, underlying, ignoreTags bool) bool {
 
-	// x is a Scriggo type, u (the interface type) can be both a Scriggo type
-	// or a gc compiled type.
-	if st, ok := x.(ScriggoType); ok {
-		return st.Implements(u)
+	// x and y are identical.
+	if x == y {
+		return true
 	}
 
-	// x is a gc compiled type, u (the interface type) is a Scriggo type.
-	if st, ok := u.(ScriggoType); ok {
-		return x.Implements(st.Underlying())
+	// x and y are not identical, ignoring tags.
+	if !underlying && !ignoreTags {
+		return false
 	}
 
-	// x is a gc compiled type, u (the interface type) is a gc compiled type.
-	return x.Implements(u) // x is implemented by the reflect package.
+	// x and y have different kind.
+	k := x.Kind()
+	if k != y.Kind() {
+		return false
+	}
 
+	// x and y are not both non-defined types.
+	if !underlying && !(x.Name() == "" && y.Name() == "") {
+		return false
+	}
+
+	// x and y have structurally equivalent underlying type literals.
+	switch k {
+	case reflect.Array:
+		return x.Len() == y.Len() && identical(x.Elem(), y.Elem(), false, ignoreTags)
+	case reflect.Slice, reflect.Ptr:
+		return identical(x.Elem(), y.Elem(), false, ignoreTags)
+	case reflect.Struct:
+		n := x.NumField()
+		if n != y.NumField() {
+			return false
+		}
+		for i := 0; i < n; i++ {
+			f1 := x.Field(i)
+			f2 := y.Field(i)
+			// Same name.
+			if f1.Name != f2.Name {
+				return false
+			}
+			// Same package for non-exported field names.
+			if f1.PkgPath != f2.PkgPath {
+				return false
+			}
+			// Identical element types.
+			if !identical(f1.Type, f2.Type, false, ignoreTags) {
+				return false
+			}
+			// Same tag, if not ignored.
+			if !ignoreTags && f1.Tag != f2.Tag {
+				return false
+			}
+			// Both embedded or both non-embedded.
+			if f1.Anonymous != f2.Anonymous {
+				return false
+			}
+			// Same offset.
+			if f1.Offset != f2.Offset {
+				return false
+			}
+		}
+	case reflect.Func:
+		in, out := x.NumIn(), x.NumOut()
+		if in != y.NumIn() || out != y.NumOut() || x.IsVariadic() != y.IsVariadic() {
+			return false
+		}
+		for i := 0; i < in; i++ {
+			if !identical(x.In(i), y.In(i), false, ignoreTags) {
+				return false
+			}
+		}
+		for i := 0; i < out; i++ {
+			if !identical(x.Out(i), y.Out(i), false, ignoreTags) {
+				return false
+			}
+		}
+	case reflect.Interface:
+		xn := x.NumMethod()
+		yn := y.NumMethod()
+		if xn != yn {
+			return false
+		}
+		for i := 0; i < xn; i++ {
+			xm := x.Method(i)
+			ym := y.Method(i)
+			// Same name.
+			if xm.Name != ym.Name {
+				return false
+			}
+			// Same package for non-exported method names.
+			if xm.PkgPath != ym.PkgPath {
+				return false
+			}
+			// Identical function types.
+			if !identical(xm.Type, ym.Type, false, ignoreTags) {
+				return false
+			}
+		}
+	case reflect.Map:
+		return identical(x.Key(), y.Key(), false, ignoreTags) && identical(x.Elem(), y.Elem(), false, ignoreTags)
+	case reflect.Chan:
+		return x.ChanDir() == y.ChanDir() && identical(x.Elem(), y.Elem(), false, ignoreTags)
+	}
+
+	return true
 }
 
 // Runtime returns a Runtime.

--- a/test/compare/testdata/fixedbugs/issue779.go
+++ b/test/compare/testdata/fixedbugs/issue779.go
@@ -1,0 +1,27 @@
+// errorcheck
+
+package main
+
+func main() {
+
+	type E1 struct {
+		x int
+	}
+	type E2 struct {
+		x int
+	}
+	type S struct {
+		x E1
+	}
+	type T struct {
+		x E2
+	}
+
+	var s S
+	_ = s
+	var t T
+	_ = t
+
+	s = S(t) // ERROR `cannot convert t (type T) to type S`
+
+}


### PR DESCRIPTION
This change revises the 'AssignableTo', 'ConvertibleTo' and 'Implements'
methods.