### PR TITLE
compiler: re-implement extends adding an import and swapping files

### DIFF
--- a/internal/compiler/checker_package.go
+++ b/internal/compiler/checker_package.go
@@ -502,7 +502,10 @@ varsLoop:
 }
 
 // checkPackage type checks a package.
-func checkPackage(compilation *compilation, pkg *ast.Package, path string, packages native.PackageLoader, opts checkerOptions) (err error) {
+//
+// extendingFile indicates whether the package pkg was originally a template
+// file that extended another template file.
+func checkPackage(compilation *compilation, pkg *ast.Package, path string, packages native.PackageLoader, opts checkerOptions, extendingFile bool) (err error) {
 
 	// If the package has already been checked just return.
 	if _, ok := compilation.pkgInfos[path]; ok {
@@ -608,6 +611,9 @@ func checkPackage(compilation *compilation, pkg *ast.Package, path string, packa
 			ti := &typeInfo{Type: funcType}
 			if f.Type.Macro {
 				ti.Properties |= propertyIsMacroDeclaration
+				if extendingFile {
+					ti.Properties |= propertyMacroDeclaredInFileWithExtends
+				}
 			}
 			tc.scopes.Declare(f.Ident.Name, ti, f.Ident)
 		}

--- a/internal/compiler/checker_statements.go
+++ b/internal/compiler/checker_statements.go
@@ -1032,7 +1032,7 @@ func (tc *typechecker) checkImport(impor *ast.Import) error {
 	}
 
 	// Check the package and retrieve the package infos.
-	err := checkPackage(tc.compilation, impor.Tree.Nodes[0].(*ast.Package), impor.Tree.Path, tc.pkgLoader, tc.opts)
+	err := checkPackage(tc.compilation, impor.Tree.Nodes[0].(*ast.Package), impor.Tree.Path, tc.pkgLoader, tc.opts, tc.compilation.extendingTrees[impor.Tree])
 	if err != nil {
 		return err
 	}

--- a/internal/compiler/compilation.go
+++ b/internal/compiler/compilation.go
@@ -67,6 +67,11 @@ type compilation struct {
 
 	// globalScope is the global scope.
 	globalScope map[string]scopeName
+
+	// extendingTrees reports if a tree was extending another file.
+	// This information must be kept here because it becomes lost after
+	// transforming the tree in case of extends.
+	extendingTrees map[*ast.Tree]bool
 }
 
 type renderIR struct {
@@ -85,6 +90,7 @@ func newCompilation(globalScope map[string]scopeName) *compilation {
 		renderImportMacro: map[*ast.Tree]renderIR{},
 		currentIteaIndex:  -1,
 		globalScope:       globalScope,
+		extendingTrees:    map[*ast.Tree]bool{},
 	}
 }
 

--- a/test/misc/templates_test.go
+++ b/test/misc/templates_test.go
@@ -3657,6 +3657,28 @@ var templateMultiFileCases = map[string]struct {
 		},
 		expectedOut: "\n\t\t\t\n\t\t\t&lt;b&gt;ciao&lt;/b&gt;\n\t\t",
 	},
+
+	// https://github.com/open2b/scriggo/issues/842
+	"Macro in extending file refers to a type defined in the same file": {
+		sources: map[string]string{
+			"index.html": `
+			{% extends "extended.html" %}
+			{% type T int %}
+			{% macro M(T) %}{% end macro %}
+		`,
+			"extended.html": ``,
+		},
+	},
+
+	"Changing the tree with extends does not impact paths of rendered and imported files": {
+		sources: map[string]string{
+			"index.html":           `{% extends "subdir/extended.html" %}`,
+			"subdir/extended.html": `{% import "i.html" for V %}{{ render "r.html" }}{{ V }}`,
+			"subdir/r.html":        ` rendered `,
+			"subdir/i.html":        `{% var V = " imported " %}`,
+		},
+		expectedOut: " rendered  imported ",
+	},
 }
 
 var structWithUnexportedFields = &struct {


### PR DESCRIPTION
This commit re-implements the 'extends' statement by swapping the
extending and the extended file and adding a dummy import statement in
the extended file.

This simplifies the code of the compiler (checker and emitter) and the
logic behind it.

Fix #842.