### PR TITLE
scriggo,native,runtime: replace 'env.Exit' with 'env.Stop'

### DIFF
--- a/cmd/scriggo/run.go
+++ b/cmd/scriggo/run.go
@@ -35,10 +35,13 @@ func run() {
 		case *scriggo.PanicError:
 			// The program panicked.
 			panic(err)
-		case scriggo.ExitError:
+		case *scriggo.ExitError:
 			// A native function has called the Stop method of native.Env with
-			// a scriggo.ExitError value.
-			os.Exit(err.Code())
+			// a *scriggo.ExitError value.
+			if err.Err != nil {
+				_, _ = fmt.Fprintln(os.Stderr, err.Err.Error())
+			}
+			os.Exit(err.Code)
 		}
 		// Another error occurred.
 		_, _ = fmt.Fprintln(os.Stderr, err)

--- a/cmd/scriggo/run.go
+++ b/cmd/scriggo/run.go
@@ -35,8 +35,9 @@ func run() {
 		case *scriggo.PanicError:
 			// The program panicked.
 			panic(err)
-		case *scriggo.ExitError:
-			// A native function has called the Exit method of native.Env.
+		case scriggo.ExitError:
+			// A native function has called the Stop method of native.Env with
+			// a scriggo.ExitError value.
 			os.Exit(err.Code())
 		}
 		// Another error occurred.

--- a/errors.go
+++ b/errors.go
@@ -50,9 +50,9 @@ func (err *BuildError) Message() string {
 	return err.err.Message()
 }
 
-// ExitError represents an exit from an execution with a non-zero code. It is
-// returned by a Run method when the Exit method of native.Env is called with
-// a non-zero value.
+// ExitError represents an exit from an execution with a status code.
+// Conventionally, an ExitError value is passed to the Stop method of
+// native.Env.
 type ExitError int
 
 // Error returns a string representation of the error.

--- a/errors.go
+++ b/errors.go
@@ -50,20 +50,34 @@ func (err *BuildError) Message() string {
 	return err.err.Message()
 }
 
-// ExitError represents an exit from an execution with a status code.
-// Conventionally, an ExitError value is passed to the Stop method of
-// native.Env.
-type ExitError int
-
-// Error returns a string representation of the error.
-func (err ExitError) Error() string {
-	return "exit code " + strconv.Itoa(int(err))
+// ExitError represents an exit from an execution with a non-zero status code.
+// It may wrap the error than caused the exit.
+//
+// An ExitError is conventionally passed to the Stop method of native.Env so
+// that the error code can be used as the process exit code.
+type ExitError struct {
+	Code int
+	Err  error
 }
 
-// Code returns the exit code.
-func (err ExitError) Code() int {
-	return int(err)
+// NewExitError returns an exit error with the given status code and error.
+// The status code should be in the range [1, 125] and err can be nil.
+// It panics if code is zero.
+func NewExitError(code int, err error) *ExitError {
+	if code == 0 {
+		panic("zero status code in NewExitError")
+	}
+	return &ExitError{Code: code, Err: err}
 }
+
+func (e *ExitError) Error() string {
+	if e.Err == nil {
+		return "exit code " + strconv.Itoa(e.Code)
+	}
+	return e.Err.Error()
+}
+
+func (e *ExitError) Unwrap() error { return e.Err }
 
 // PanicError represents the error that occurs when an executed program or
 // template calls the panic built-in and the panic is not recovered.

--- a/errors.go
+++ b/errors.go
@@ -51,7 +51,7 @@ func (err *BuildError) Message() string {
 }
 
 // ExitError represents an exit from an execution with a non-zero status code.
-// It may wrap the error than caused the exit.
+// It may wrap the error that caused the exit.
 //
 // An ExitError is conventionally passed to the Stop method of native.Env so
 // that the error code can be used as the process exit code.

--- a/internal/runtime/env.go
+++ b/internal/runtime/env.go
@@ -43,10 +43,6 @@ func (env *env) Context() context.Context {
 	return env.ctx
 }
 
-func (env *env) Exit(code int) {
-	panic(exitError(code))
-}
-
 func (env *env) Fatal(v interface{}) {
 	panic(&fatalError{env: env, msg: v})
 }
@@ -65,6 +61,10 @@ func (env *env) Println(args ...interface{}) {
 		env.doPrint(arg)
 	}
 	env.doPrint("\n")
+}
+
+func (env *env) Stop(err error) {
+	panic(stopError{err})
 }
 
 func (env *env) TypeOf(v reflect.Value) reflect.Type {

--- a/internal/runtime/errors.go
+++ b/internal/runtime/errors.go
@@ -73,11 +73,13 @@ func errTypeAssertion(interfaceType, dynamicType, assertedType reflect.Type, mis
 	return runtimeError(s + "packages)")
 }
 
-// exitError represents an exit error.
-type exitError int
+// stopError represents a stop error.
+type stopError struct {
+	err error
+}
 
-func (err exitError) Error() string {
-	return "exit code " + strconv.Itoa(int(err))
+func (err stopError) Error() string {
+	return "stop: " + err.Error()
 }
 
 // errIndexOutOfRange returns an index of range runtime error for the
@@ -114,7 +116,7 @@ func (vm *VM) newPanic(msg interface{}) *PanicError {
 // convertPanic converts a panic to an error.
 func (vm *VM) convertPanic(msg interface{}) error {
 	switch err := msg.(type) {
-	case exitError:
+	case stopError:
 		return err
 	case outError:
 		return vm.newPanic(err)

--- a/internal/runtime/vm.go
+++ b/internal/runtime/vm.go
@@ -144,7 +144,7 @@ func (vm *VM) stop() (Addr, bool) {
 // If a context has been set and the context is canceled, Run returns
 // as soon as possible with the error returned by the Err method of the
 // context.
-func (vm *VM) Run(fn *Function, typeof TypeOfFunc, globals []reflect.Value) (int, error) {
+func (vm *VM) Run(fn *Function, typeof TypeOfFunc, globals []reflect.Value) error {
 	if typeof == nil {
 		typeof = typeOfFunc
 	}
@@ -159,12 +159,12 @@ func (vm *VM) Run(fn *Function, typeof TypeOfFunc, globals []reflect.Value) (int
 			}
 		case *fatalError:
 			panic(e.msg)
-		case exitError:
-			return int(e), nil
+		case stopError:
+			err = e.err
 		}
-		return 0, err
+		return err
 	}
-	return 0, nil
+	return nil
 }
 
 // SetContext sets the context.

--- a/native/native.go
+++ b/native/native.go
@@ -58,9 +58,6 @@ type Env interface {
 
 	// Stop stops the execution with the given error. Deferred functions are
 	// not called and started goroutines are not terminated.
-	//
-	// Conventionally, a scriggo.ExitError value represents an execution
-	// exited with a given status code.
 	Stop(err error)
 
 	// TypeOf is like reflect.TypeOf but if v has a Scriggo type it returns

--- a/native/native.go
+++ b/native/native.go
@@ -46,12 +46,6 @@ type Env interface {
 	// It is the context passed as an option for execution.
 	Context() context.Context
 
-	// Exit exits the execution with the given status code. If the code is not
-	// zero, the execution returns a scriggo.ExitError error with this code.
-	// Deferred functions are not called and started goroutines are not
-	// terminated.
-	Exit(code int)
-
 	// Fatal exits the execution and then panics with value v. Deferred
 	// functions are not called and started goroutines are not terminated.
 	Fatal(v interface{})
@@ -61,6 +55,13 @@ type Env interface {
 
 	// Println calls the println built-in function with args as argument.
 	Println(args ...interface{})
+
+	// Stop stops the execution with the given error. Deferred functions are
+	// not called and started goroutines are not terminated.
+	//
+	// Conventionally, a scriggo.ExitError value represents an execution
+	// exited with a given status code.
+	Stop(err error)
 
 	// TypeOf is like reflect.TypeOf but if v has a Scriggo type it returns
 	// its Scriggo reflect type instead of the reflect type of the proxy.

--- a/programs.go
+++ b/programs.go
@@ -122,14 +122,14 @@ func (p *Program) Disassemble(pkgPath string) ([]byte, error) {
 // If the executed program panics, and it is not recovered, Run returns a
 // *PanicError.
 //
-// If the Exit method of native.Env is called with a non-zero code, Run
-// returns a *ExitError with the exit code.
+// If the Stop method of native.Env is called, Run returns the argument passed
+// to Stop.
 //
-// If the Fatal method of native.Env is called with argument v, Run panics
-// with the value v.
+// If the Fatal method of native.Env is called, Run panics with the argument
+// passed to Fatal.
 //
-// If the context has been canceled, Run returns the error returned by
-// options.Context.Err().
+// If the context has been canceled, Run returns the error returned by the Err
+// method of the context.
 func (p *Program) Run(options *RunOptions) error {
 	vm := runtime.NewVM()
 	if options != nil {
@@ -140,15 +140,12 @@ func (p *Program) Run(options *RunOptions) error {
 			vm.SetPrint(runtime.PrintFunc(options.Print))
 		}
 	}
-	code, err := vm.Run(p.fn, p.typeof, initPackageLevelVariables(p.globals))
+	err := vm.Run(p.fn, p.typeof, initPackageLevelVariables(p.globals))
 	if err != nil {
 		if p, ok := err.(*runtime.PanicError); ok {
 			err = &PanicError{p}
 		}
 		return err
-	}
-	if code != 0 {
-		return ExitError(code)
 	}
 	return nil
 }

--- a/scripts/scripts.go
+++ b/scripts/scripts.go
@@ -88,14 +88,17 @@ func (p *Script) Disassemble() []byte {
 // If the executed script panics, and it is not recovered, Run returns a
 // *PanicError.
 //
-// If the Exit method of native.Env is called, or the exit built-in is called,
-// with a non-zero code, Run returns a *ExitError with the exit code.
+// If the Stop method of native.Env is called, Run returns the argument passed
+// to Stop.
 //
-// If the Fatal method of native.Env is called with argument v, Run panics
-// with the value v.
+// If the exit builtin is called, Run returns a scriggo.ExitError with the
+// exit code.
 //
-// If the context has been canceled, Run returns the error returned by
-// options.Context.Err().
+// If the Fatal method of native.Env is called, Run panics with the argument
+// passed to Fatal.
+//
+// If the context has been canceled, Run returns the error returned by the Err
+// method of the context.
 func (p *Script) Run(vars map[string]interface{}, options *RunOptions) error {
 	vm := runtime.NewVM()
 	if options != nil {
@@ -106,15 +109,12 @@ func (p *Script) Run(vars map[string]interface{}, options *RunOptions) error {
 			vm.SetPrint(runtime.PrintFunc(options.Print))
 		}
 	}
-	code, err := vm.Run(p.fn, p.typeof, initGlobalVariables(p.globals, vars))
+	err := vm.Run(p.fn, p.typeof, initGlobalVariables(p.globals, vars))
 	if err != nil {
 		if p, ok := err.(*runtime.PanicError); ok {
 			err = &PanicError{p}
 		}
 		return err
-	}
-	if code != 0 {
-		return scriggo.ExitError(code)
 	}
 	return nil
 }

--- a/templates.go
+++ b/templates.go
@@ -111,14 +111,14 @@ func BuildTemplate(fsys fs.FS, name string, options *BuildOptions) (*Template, e
 // If the executed template panics, and it is not recovered, Run returns a
 // *PanicError.
 //
-// If the Exit method of native.Env is called with a non-zero code, Run
-// returns a *ExitError with the exit code.
+// If the Stop method of native.Env is called, Run returns the argument passed
+// to Stop.
 //
-// If the Fatal method of native.Env is called with argument v, Run panics
-// with the value v.
+// If the Fatal method of native.Env is called, Run panics with the argument
+// passed to Fatal.
 //
-// If the context has been canceled, Run returns the error returned by
-// options.Context.Err().
+// If the context has been canceled, Run returns the error returned by the Err
+// method of the context.
 //
 // If a call to out.Write returns an error, a panic occurs. If the executed
 // code does not recover the panic, Run returns the error returned by
@@ -137,15 +137,12 @@ func (t *Template) Run(out io.Writer, vars map[string]interface{}, options *RunO
 		}
 	}
 	vm.SetRenderer(out, t.conv)
-	code, err := vm.Run(t.fn, t.typeof, initGlobalVariables(t.globals, vars))
+	err := vm.Run(t.fn, t.typeof, initGlobalVariables(t.globals, vars))
 	if err != nil {
 		if p, ok := err.(*runtime.PanicError); ok {
 			err = &PanicError{p}
 		}
 		return err
-	}
-	if code != 0 {
-		return ExitError(code)
 	}
 	return nil
 }

--- a/test/misc/env_test.go
+++ b/test/misc/env_test.go
@@ -196,3 +196,26 @@ func TestStop(t *testing.T) {
 		t.Fatalf("expected stop error, got %q", err)
 	}
 }
+
+// TestStopWithExit tests the Stop method of native.Env with an *ExitError as
+// argument.
+func TestStopWithExit(t *testing.T) {
+	errExit := scriggo.NewExitError(1, nil)
+	fsys := fstest.Files{"index": "{% exit() %}"}
+	opts := &scriggo.BuildOptions{
+		Globals: native.Declarations{
+			"exit": func(env native.Env) { env.Stop(errExit) },
+		},
+	}
+	template, err := scriggo.BuildTemplate(fsys, "index", opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = template.Run(os.Stdout, nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got no errors")
+	}
+	if err != errExit {
+		t.Fatalf("expected exit error, got %q", err)
+	}
+}

--- a/test/misc/env_test.go
+++ b/test/misc/env_test.go
@@ -7,7 +7,9 @@ package misc
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/open2b/scriggo"
@@ -170,5 +172,27 @@ func TestEnvStringer(t *testing.T) {
 				t.Fatalf("(-want, +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestStop tests the Stop method of native.Env.
+func TestStop(t *testing.T) {
+	errStop := errors.New("stopped")
+	fsys := fstest.Files{"index": "{% stop() %}"}
+	opts := &scriggo.BuildOptions{
+		Globals: native.Declarations{
+			"stop": func(env native.Env) { env.Stop(errStop) },
+		},
+	}
+	template, err := scriggo.BuildTemplate(fsys, "index", opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = template.Run(os.Stdout, nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got no errors")
+	}
+	if err != errStop {
+		t.Fatalf("expected stop error, got %q", err)
 	}
 }


### PR DESCRIPTION
This change replaces the 'Exit' method of the 'native.Env' interface
with the 'Stop' method. The 'Stop' method has the same behaviour of
'Exit' but accepts an error instead of a status code.

The following code:

```go
env.Exit(0)
env.Exit(2)
```
with this change, can be rewritten as

```go
env.Stop(nil)
env.Stop(scriggo.NewExitError(2, nil))
```