### PR TITLE
builtins: add Unsafeconv package declaration

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -6,8 +6,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package builtin provides simple functions, types and constants that can be
-// used as globals in a Scriggo template.
+// Package builtin provides simple functions, types, constants and a package
+// that can be used as globals in a Scriggo template.
 //
 // For example, to use the Min and Max functions as global min and max
 // functions

--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -122,6 +122,9 @@
 //  	"parseTime":     builtin.ParseTime,
 //  	"unixTime":      builtin.UnixTime,
 //
+//  	// unsafeconv, uncomment the declaration below to allow to use unsafe conversions between string and native types
+//  	// "unsafeconv":    builtin.Unsafeconv,
+//
 //  }
 //
 // To initialize the form builtin value, with data read from the request r,

--- a/builtin/builtin_test.go
+++ b/builtin/builtin_test.go
@@ -15,6 +15,12 @@ import (
 var sp = fmt.Sprint
 var spf = fmt.Sprintf
 
+var toHTML = Unsafeconv.Declarations["ToHTML"].(func(string) native.HTML)
+var toCSS = Unsafeconv.Declarations["ToCSS"].(func(string) native.CSS)
+var toJS = Unsafeconv.Declarations["ToJS"].(func(string) native.JS)
+var toJSON = Unsafeconv.Declarations["ToJSON"].(func(string) native.JSON)
+var toMarkdown = Unsafeconv.Declarations["ToMarkdown"].(func(string) native.Markdown)
+
 var tests = []struct {
 	got      string
 	expected string
@@ -297,6 +303,13 @@ var tests = []struct {
 	{spf("%v", UnmarshalJSON("", (*int)(nil))), "unmarshalJSON: cannot unmarshal into a nil pointer of type *int"},
 	{spf("%v", UnmarshalJSON("", []int{})), "unmarshalJSON: cannot unmarshal into non-pointer value of type []int"},
 	{spf("%v", UnmarshalJSON("5", &[]int{})), "unmarshalJSON: cannot unmarshal number into value of type []int"},
+
+	// unsafeconv
+	{string(toHTML("<a>")), "<a>"},
+	{string(toCSS("#AAA")), "#AAA"},
+	{string(toJS("= undefined;")), "= undefined;"},
+	{string(toJSON("[ 1, 2, 3 ]")), "[ 1, 2, 3 ]"},
+	{string(toMarkdown("# a title")), "# a title"},
 }
 
 func TestBuiltins(t *testing.T) {

--- a/builtin/unsafeconv.go
+++ b/builtin/unsafeconv.go
@@ -1,0 +1,40 @@
+// Copyright 2021 The Scriggo Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package builtin
+
+import (
+	"github.com/open2b/scriggo/native"
+)
+
+// Unsafeconv provides a package that contains functions to make unsafe conversions between string values and native
+// types.
+//
+// Use these build options to use it in a template
+//    opts := &scriggo.BuildOptions{
+//        Globals: map[string]native.Declaration{
+//            "unsafeconv": builtin.Unsafeconv,
+//        },
+//    }
+//    template, err := scriggo.BuildTemplate(fsys, file, opts)
+var Unsafeconv = native.Package{
+	Name: "unsafeconv",
+	Declarations: map[string]native.Declaration{
+		"ToHTML": func(str string) native.HTML {
+			return native.HTML(str)
+		},
+		"ToCSS": func(str string) native.CSS {
+			return native.CSS(str)
+		},
+		"ToJS": func(str string) native.JS {
+			return native.JS(str)
+		},
+		"ToJSON": func(str string) native.JSON {
+			return native.JSON(str)
+		},
+		"ToMarkdown": func(str string) native.Markdown {
+			return native.Markdown(str)
+		},
+	},
+}

--- a/builtin/unsafeconv.go
+++ b/builtin/unsafeconv.go
@@ -8,16 +8,8 @@ import (
 	"github.com/open2b/scriggo/native"
 )
 
-// Unsafeconv provides a package that contains functions to make unsafe conversions between string values and native
-// types.
-//
-// Use these build options to use it in a template
-//    opts := &scriggo.BuildOptions{
-//        Globals: map[string]native.Declaration{
-//            "unsafeconv": builtin.Unsafeconv,
-//        },
-//    }
-//    template, err := scriggo.BuildTemplate(fsys, file, opts)
+// Unsafeconv provides a package that implements functions to make unsafe
+// conversions between string values and native types.
 var Unsafeconv = native.Package{
 	Name: "unsafeconv",
 	Declarations: map[string]native.Declaration{

--- a/builtin/unsafeconv.go
+++ b/builtin/unsafeconv.go
@@ -21,20 +21,20 @@ import (
 var Unsafeconv = native.Package{
 	Name: "unsafeconv",
 	Declarations: map[string]native.Declaration{
-		"ToHTML": func(str string) native.HTML {
-			return native.HTML(str)
+		"ToHTML": func(s string) native.HTML {
+			return native.HTML(s)
 		},
-		"ToCSS": func(str string) native.CSS {
-			return native.CSS(str)
+		"ToCSS": func(s string) native.CSS {
+			return native.CSS(s)
 		},
-		"ToJS": func(str string) native.JS {
-			return native.JS(str)
+		"ToJS": func(s string) native.JS {
+			return native.JS(s)
 		},
-		"ToJSON": func(str string) native.JSON {
-			return native.JSON(str)
+		"ToJSON": func(s string) native.JSON {
+			return native.JSON(s)
 		},
-		"ToMarkdown": func(str string) native.Markdown {
-			return native.Markdown(str)
+		"ToMarkdown": func(s string) native.Markdown {
+			return native.Markdown(s)
 		},
 	},
 }


### PR DESCRIPTION
This change adds a package declaration to `builtin` that provides functions to (unsafely) convert between string and native types 