### PR TITLE
compiler/checker: call types.New instead of reflect.New in setValue

### DIFF
--- a/internal/compiler/typeinfo.go
+++ b/internal/compiler/typeinfo.go
@@ -6,6 +6,8 @@ package compiler
 
 import (
 	"reflect"
+
+	"github.com/open2b/scriggo/internal/runtime"
 )
 
 type properties uint16
@@ -266,7 +268,11 @@ func (ti *typeInfo) setValue(typ reflect.Type) {
 		case complex128Type:
 			ti.value = c
 		default:
-			rv := reflect.New(ti.valueType).Elem()
+			typ := ti.valueType
+			if st, ok := typ.(runtime.ScriggoType); ok {
+				typ = st.GoType()
+			}
+			rv := reflect.New(typ).Elem()
 			rv.SetComplex(c)
 			ti.value = rv.Interface()
 		}

--- a/test/compare/testdata/fixedbugs/issue887.go
+++ b/test/compare/testdata/fixedbugs/issue887.go
@@ -1,0 +1,10 @@
+// run
+
+package main
+
+type C64 complex64
+
+func main() {
+	var c C64
+	_ = c
+}

--- a/test/compare/testdata/github.com-golang-go/cmplx.go
+++ b/test/compare/testdata/github.com-golang-go/cmplx.go
@@ -1,4 +1,4 @@
-// skip : defined type with underlying type complex (https://github.com/open2b/scriggo/issues/887)
+// skip : investigate
 
 // errorcheck
 


### PR DESCRIPTION
Fix #887.

Also see #829.