### PR TITLE
compiler/builder: fix 32-bit compilation of Scriggo

### DIFF
--- a/internal/compiler/builder.go
+++ b/internal/compiler/builder.go
@@ -577,8 +577,8 @@ func (fb *functionBuilder) end() {
 	// if len(fn.Body) == 0 || fn.Body[len(fn.Body)-1].Op != runtime.OpReturn {
 	// 	fb.emitReturn()
 	// }
-	if len(fn.Body) > math.MaxUint32 {
-		panic(newLimitExceededError(fn.Pos, fn.File, "instructions count exceeded %d", math.MaxUint32))
+	if int64(len(fn.Body)) > math.MaxUint32 {
+		panic(newLimitExceededError(fn.Pos, fn.File, "instructions count exceeded %d", uint32(math.MaxUint32)))
 	}
 	for addr, label := range fb.gotos {
 		i := fn.Body[addr]


### PR DESCRIPTION
This change fixes the compilation of Scriggo on 32-bit architectures.

Note that Scriggo is not currently supported on 32-bit architectures and
this change does not add support for it.

Fixes #901