### PR TITLE
compiler/emitter: optimize '{{ render .. }}'

### DIFF
--- a/internal/compiler/emitter_statements.go
+++ b/internal/compiler/emitter_statements.go
@@ -299,6 +299,12 @@ func (em *emitter) emitNodes(nodes []ast.Node) {
 					em.fb.enterStack()
 					em.emitCallNode(expr.(*ast.Call), false, false, ast.Format(ctx))
 					em.fb.exitStack()
+				} else if render, ok := expr.(*ast.Render); ok {
+					// Optimize {{ render "path" }}
+					em.fb.enterStack()
+					em.emitNodes([]ast.Node{render.IR.Import})
+					em.emitCallNode(render.IR.Call, false, false, ast.Format(ctx))
+					em.fb.exitStack()
 				} else {
 					ti := em.ti(expr)
 					em.fb.enterStack()


### PR DESCRIPTION
Close #903.

Details:

## Benchmark source code

index.html:

	{{ render "rendered.html" }}

rendered.html:

	something

## Disassembled code

Without optimization:

	Macro main
		; regs(0,0,3,0)
		Call main.M"rendered.html" _ _ s3 _	; macro
		Move s3 s2
		Show native.HTML s2 (HTML)
		Return

	Macro M"rendered.html" (s1 native.HTML)
		; regs(0,0,2,0)
		Move "" s2
		Move s2 s1
		Text "something"
		Return
		
With optimization:

	Macro main
		; regs(0,0,1,0)
		Call main.M"rendered.html" _ _ s1 _	; macro
		Return

	Macro M"rendered.html" (s1 native.HTML)
		; regs(0,0,2,0)
		Move "" s2
		Move s2 s1
		Text "something"
		Return

## Benchmarks

Without optimization:

	BenchmarkRender-4   	   23613	     47945 ns/op	   50312 B/op	     239 allocs/op

With optimization:

	BenchmarkRender-4   	   25502	     46397 ns/op	   50136 B/op	     232 allocs/op