### PR TITLE
compiler/checker: fix call to 'setValue' 

### DIFF
--- a/internal/compiler/checker_assignment.go
+++ b/internal/compiler/checker_assignment.go
@@ -89,7 +89,7 @@ func (tc *typechecker) checkAssignment(node *ast.Assignment) {
 		if ti.Nil() {
 			tc.compilation.typeInfos[nodeRhs[i]] = tc.nilOf(lhs[i].Type)
 		} else {
-			ti.setValue(nil)
+			ti.setValue(lhs[i].Type)
 		}
 	}
 

--- a/test/compare/testdata/fixedbugs/issue917a.go
+++ b/test/compare/testdata/fixedbugs/issue917a.go
@@ -1,0 +1,15 @@
+// run
+
+package main
+
+import "fmt"
+
+var x complex128
+
+func main() {
+	x = 3i
+	y := x
+	x = 0
+	fmt.Printf("x: %#v\n", x)
+	fmt.Printf("y: %#v\n", y)
+}

--- a/test/compare/testdata/fixedbugs/issue917b.go
+++ b/test/compare/testdata/fixedbugs/issue917b.go
@@ -1,0 +1,9 @@
+// run
+
+package main
+
+func main() {
+	x := 3i
+	x = 0
+	println(x)
+}

--- a/test/compare/testdata/fixedbugs/issue917c.go
+++ b/test/compare/testdata/fixedbugs/issue917c.go
@@ -1,0 +1,18 @@
+// run
+
+package main
+
+import "fmt"
+
+var x complex64
+
+func main() {
+	x = 3i
+	y := x
+	x = 0
+	fmt.Printf("x: %#v\n", x)
+	fmt.Printf("y: %#v\n", y)
+	x = 32
+	fmt.Printf("x: %#v\n", x)
+	fmt.Printf("y: %#v\n", y)
+}

--- a/test/compare/testdata/fixedbugs/issue917d.go
+++ b/test/compare/testdata/fixedbugs/issue917d.go
@@ -1,0 +1,9 @@
+// run
+
+package main
+
+func main() {
+	var x int
+	x = 10 + 0i
+	println(x)
+}


### PR DESCRIPTION
Currently, when assigning a value of a type T1 to a variable of type T2,
if such assignment requires an implicit conversion then such conversion
is performed at runtime, calling the 'OpConvert'.

This is not correct and leads to problems.

This commit avoids that by calling 'setValue' passing it the correct
type instead of nil, so the conversion is performed at compile time.

Fix #917.

Co-authored-by: Marco Gazerro <gazerro@open2b.com>