### PR TITLE
compiler/parser: fix panic on invalid default left expression

### DIFF
--- a/internal/compiler/parser_expressions.go
+++ b/internal/compiler/parser_expressions.go
@@ -434,11 +434,16 @@ func (p *parsing) parseExpr(tok token, canBeSwitchGuard, canElideType, mustBeTyp
 					pos := tok.pos
 					pos.Start = operand.Pos().Start
 					node := ast.NewDefault(pos, operand, nil)
-					if _, ok := operand.(*ast.Render); ok {
+					switch operand.(type) {
+					case *ast.Identifier:
+					case *ast.Call:
+					case *ast.Render:
 						// Replace the Render node with the Default node in the unexpanded
 						// slice because, when the tree is expanded, the parser needs to know
 						// if the render expression is used in a default expression.
 						p.unexpanded[len(p.unexpanded)-1] = node
+					default:
+						panic(syntaxError(operand.Pos(), "unexpected %s, expecting identifier, call or render", operand))
 					}
 					node.Expr2, tok = p.parseExpr(p.next(), false, false, false, nextIsBlockBrace)
 					if node.Expr2 == nil {

--- a/test/misc/templates_test.go
+++ b/test/misc/templates_test.go
@@ -2720,6 +2720,13 @@ var templateMultiFileCases = map[string]struct {
 		expectedBuildErr: `const initializer render "partial.html" is not a constant`,
 	},
 
+	"Default with invalid left expression": {
+		sources: fstest.Files{
+			"index.txt": `{% if sortBy := sortBy.(html) default ""; sortBy %}{% end if %}`,
+		},
+		expectedBuildErr: `unexpected sortBy.(html), expecting identifier, call or render`,
+	},
+
 	"Removed special render assignment form": {
 		sources: fstest.Files{
 			"index.html":   `{% var s string %}{% var ok bool %}{% s, ok = render "partial.html" %}`,


### PR DESCRIPTION
If the left expression of a 'default' expression is not an identifier, call, or rendering expression, the compiler panics instead of returning an error.

Fixes #942