### PR TITLE
scriggo: update `golang.org/x/tools` to `v0.13.0`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.4
 	github.com/yuin/goldmark v1.4.12
 	golang.org/x/mod v0.5.1
-	golang.org/x/tools v0.1.9
+	golang.org/x/tools v0.13.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 


### PR DESCRIPTION
## Commit Message

```
scriggo: update `golang.org/x/tools` to `v0.13.0`

This commit updates the version of 'golang.org/x/tools' to resolve a
panic that occurs when running 'scriggo import' due to some
incompatibility between the new versions of the Go compiler and the
version of this package we are currently using.

Version 'v0.13.0' is the minimum version for which the panic does not
occur; we chose to update to the minimum necessary version rather than
the latest to reduce the chances of incompatibility with older versions
of the compiler.
```