### PR TITLE
internal/runtime: refactor macro calls and renderer implementation

### DIFF
--- a/internal/runtime/env.go
+++ b/internal/runtime/env.go
@@ -21,6 +21,7 @@ type env struct {
 	globals []reflect.Value // global variables.
 	print   PrintFunc       // custom print builtin.
 	typeof  TypeOfFunc      // typeof function.
+	conv    Converter       // Markdown converter
 
 	done     int32
 	doneChan <-chan struct{}

--- a/internal/runtime/renderer.go
+++ b/internal/runtime/renderer.go
@@ -6,7 +6,6 @@ package runtime
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"html"
 	"io"
@@ -48,13 +47,6 @@ type renderer struct {
 // newRenderer returns a new renderer.
 func newRenderer(out io.Writer) *renderer {
 	return &renderer{out: out}
-}
-
-func (r *renderer) Close() error {
-	if w, ok := r.out.(*markdownWriter); ok {
-		return w.Close()
-	}
-	return nil
 }
 
 // Show shows v in the given context.
@@ -195,33 +187,6 @@ func (r *renderer) endURL() {
 	r.query = false
 	r.addAmpersand = false
 	r.removeQuestionMark = false
-}
-
-// markdownWriter implements an io.WriteCloser that writes to the buffer buf.
-// When the Close method is called, it converts the content in the buffer,
-// using converter, from Markdown to HTML and writes it to out.
-type markdownWriter struct {
-	buf     bytes.Buffer
-	convert Converter
-	out     io.Writer
-}
-
-// newMarkdownWriter returns a *markdownWriter value that writes to out the
-// Markdown code converted to HTML by converter.
-func newMarkdownWriter(out io.Writer, converter Converter) *markdownWriter {
-	var buf bytes.Buffer
-	return &markdownWriter{buf, converter, out}
-}
-
-func (w *markdownWriter) Write(p []byte) (int, error) {
-	return w.buf.Write(p)
-}
-
-func (w *markdownWriter) Close() error {
-	if w.convert == nil {
-		return errors.New("no Markdown convert available")
-	}
-	return w.convert(w.buf.Bytes(), w.out)
 }
 
 type strWriterWrapper struct {

--- a/internal/runtime/renderer.go
+++ b/internal/runtime/renderer.go
@@ -165,10 +165,6 @@ func (r *renderer) WithConversion(from, to ast.Format) *renderer {
 	return &renderer{out: r.out, conv: r.conv}
 }
 
-func (r *renderer) WithOut(out io.Writer) *renderer {
-	return &renderer{out: out}
-}
-
 // showInURL shows v in a URL in the given context.
 func (r *renderer) showInURL(env *env, v interface{}, ctx ast.Context) error {
 

--- a/internal/runtime/renderer.go
+++ b/internal/runtime/renderer.go
@@ -157,14 +157,6 @@ func (r *renderer) Text(txt []byte, inURL, isSet bool) error {
 	return err
 }
 
-func (r *renderer) WithConversion(from, to ast.Format) *renderer {
-	if from == ast.FormatMarkdown && to == ast.FormatHTML {
-		out := newMarkdownWriter(r.out, r.conv)
-		return &renderer{out: out, conv: r.conv}
-	}
-	return &renderer{out: r.out, conv: r.conv}
-}
-
 // showInURL shows v in a URL in the given context.
 func (r *renderer) showInURL(env *env, v interface{}, ctx ast.Context) error {
 

--- a/internal/runtime/renderer.go
+++ b/internal/runtime/renderer.go
@@ -166,7 +166,7 @@ func (r *renderer) WithConversion(from, to ast.Format) *renderer {
 }
 
 func (r *renderer) WithOut(out io.Writer) *renderer {
-	return &renderer{out: out, conv: r.conv}
+	return &renderer{out: out}
 }
 
 // showInURL shows v in a URL in the given context.

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -6,6 +6,7 @@ package runtime
 
 import (
 	"bytes"
+	"errors"
 	"reflect"
 	"strings"
 	"sync/atomic"
@@ -294,6 +295,9 @@ func (vm *VM) run() (Addr, bool) {
 						vm.renderer = newRenderer(&strings.Builder{})
 					} else if ast.Format(b) != fn.Format {
 						if fn.Format == ast.FormatMarkdown && ast.Format(b) == ast.FormatHTML {
+							if vm.env.conv == nil {
+								panic(&fatalError{env: vm.env, msg: errors.New("no Markdown convert available")})
+							}
 							vm.renderer = newRenderer(&bytes.Buffer{})
 						} else {
 							vm.renderer = newRenderer(vm.renderer.out)
@@ -329,6 +333,9 @@ func (vm *VM) run() (Addr, bool) {
 				vm.renderer = newRenderer(&strings.Builder{})
 			} else if ast.Format(b) != fn.Format {
 				if fn.Format == ast.FormatMarkdown && ast.Format(b) == ast.FormatHTML {
+					if vm.env.conv == nil {
+						panic(&fatalError{env: vm.env, msg: errors.New("no Markdown convert available")})
+					}
 					vm.renderer = newRenderer(&bytes.Buffer{})
 				} else {
 					vm.renderer = newRenderer(vm.renderer.out)

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -291,13 +291,13 @@ func (vm *VM) run() (Addr, bool) {
 				if fn.Macro {
 					call.renderer = vm.renderer
 					if b == ReturnString {
-						vm.renderer = newRenderer(&macroOutBuffer{}, nil)
+						vm.renderer = newRenderer(&macroOutBuffer{})
 					} else if ast.Format(b) != fn.Format {
 						if fn.Format == ast.FormatMarkdown && ast.Format(b) == ast.FormatHTML {
-							out := newMarkdownWriter(vm.renderer.out, vm.renderer.conv)
-							vm.renderer = newRenderer(out, vm.renderer.conv)
+							out := newMarkdownWriter(vm.renderer.out, vm.conv)
+							vm.renderer = newRenderer(out)
 						} else {
-							vm.renderer = newRenderer(vm.renderer.out, vm.renderer.conv)
+							vm.renderer = newRenderer(vm.renderer.out)
 						}
 					}
 				}
@@ -327,13 +327,13 @@ func (vm *VM) run() (Addr, bool) {
 				vm.moreGeneralStack()
 			}
 			if b == ReturnString {
-				vm.renderer = newRenderer(&macroOutBuffer{}, nil)
+				vm.renderer = newRenderer(&macroOutBuffer{})
 			} else if ast.Format(b) != fn.Format {
 				if fn.Format == ast.FormatMarkdown && ast.Format(b) == ast.FormatHTML {
-					out := newMarkdownWriter(vm.renderer.out, vm.renderer.conv)
-					vm.renderer = newRenderer(out, vm.renderer.conv)
+					out := newMarkdownWriter(vm.renderer.out, vm.conv)
+					vm.renderer = newRenderer(out)
 				} else {
-					vm.renderer = newRenderer(vm.renderer.out, vm.renderer.conv)
+					vm.renderer = newRenderer(vm.renderer.out)
 				}
 			}
 			vm.fn = fn
@@ -523,9 +523,9 @@ func (vm *VM) run() (Addr, bool) {
 				vm.setGeneral(c, v.Convert(t))
 			} else {
 				var b bytes.Buffer
-				r1 := newRenderer(&b, vm.renderer.conv)
-				out := newMarkdownWriter(r1.out, r1.conv)
-				r2 := newRenderer(out, r1.conv)
+				r1 := newRenderer(&b)
+				out := newMarkdownWriter(r1.out, vm.conv)
+				r2 := newRenderer(out)
 				_, _ = r2.Out().Write([]byte(v.String()))
 				_ = r2.Close()
 				_ = r1.Close()
@@ -1797,7 +1797,7 @@ func (vm *VM) run() (Addr, bool) {
 			if rv.IsValid() {
 				v = rv.Interface()
 			}
-			err := vm.renderer.Show(vm.env, v, Context(c))
+			err := vm.renderer.Show(vm.env, v, Context(c), vm.conv)
 			if err != nil {
 				panic(outError{err})
 			}

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -513,7 +513,7 @@ func (vm *VM) run() (Addr, bool) {
 				vm.setGeneral(c, v.Convert(t))
 			} else {
 				var b bytes.Buffer
-				r1 := vm.renderer.WithOut(&b)
+				r1 := newRenderer(&b, vm.renderer.conv)
 				r2 := r1.WithConversion(ast.FormatMarkdown, ast.FormatHTML)
 				_, _ = r2.Out().Write([]byte(v.String()))
 				_ = r2.Close()

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -520,9 +520,11 @@ func (vm *VM) run() (Addr, bool) {
 			if t.Kind() == reflect.Slice {
 				vm.setGeneral(c, v.Convert(t))
 			} else {
-				var b strings.Builder
-				_ = vm.env.conv([]byte(v.String()), &b)
-				vm.setString(c, b.String())
+				if vm.env.conv != nil {
+					var b strings.Builder
+					_ = vm.env.conv([]byte(v.String()), &b)
+					vm.setString(c, b.String())
+				}
 			}
 
 		// Concat

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -5,7 +5,6 @@
 package runtime
 
 import (
-	"bytes"
 	"reflect"
 	"strings"
 	"sync/atomic"
@@ -522,13 +521,8 @@ func (vm *VM) run() (Addr, bool) {
 			if t.Kind() == reflect.Slice {
 				vm.setGeneral(c, v.Convert(t))
 			} else {
-				var b bytes.Buffer
-				r1 := newRenderer(&b)
-				out := newMarkdownWriter(r1.out, vm.conv)
-				r2 := newRenderer(out)
-				_, _ = r2.Out().Write([]byte(v.String()))
-				_ = r2.Close()
-				_ = r1.Close()
+				var b strings.Builder
+				_ = vm.conv([]byte(v.String()), &b)
 				vm.setString(c, b.String())
 			}
 

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -1568,14 +1568,15 @@ func (vm *VM) run() (Addr, bool) {
 				return maxUint32, false
 			}
 			call := vm.calls[i]
+			fn := call.cl.fn
 			if call.status == started {
 				if vm.fn.Macro {
 					if call.renderer != vm.renderer {
-						b := call.cl.fn.Body[call.pc-2].B
+						b := fn.Body[call.pc-2].B
 						if b == ReturnString {
 							out := vm.renderer.Out().(*strings.Builder)
 							vm.setString(1, out.String())
-						} else if ast.Format(b) != call.cl.fn.Format {
+						} else if fn.Format == ast.FormatMarkdown && ast.Format(b) == ast.FormatHTML {
 							out := vm.renderer.Out().(*bytes.Buffer)
 							err := vm.env.conv(out.Bytes(), call.renderer.out)
 							if err != nil {
@@ -1589,7 +1590,7 @@ func (vm *VM) run() (Addr, bool) {
 				}
 				vm.calls = vm.calls[:i]
 				vm.fp = call.fp
-				vm.fn = call.cl.fn
+				vm.fn = fn
 				vm.vars = call.cl.vars
 				vm.pc = call.pc
 			} else if !vm.nextCall() {

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -520,7 +520,7 @@ func (vm *VM) run() (Addr, bool) {
 				vm.setGeneral(c, v.Convert(t))
 			} else {
 				var b strings.Builder
-				_ = vm.conv([]byte(v.String()), &b)
+				_ = vm.env.conv([]byte(v.String()), &b)
 				vm.setString(c, b.String())
 			}
 
@@ -1576,7 +1576,7 @@ func (vm *VM) run() (Addr, bool) {
 						case *macroOutBuffer:
 							vm.setString(1, out.String())
 						case *markdownOutBuffer:
-							err = vm.conv(out.Bytes(), call.renderer.out)
+							err = vm.env.conv(out.Bytes(), call.renderer.out)
 						}
 						if err != nil {
 							panic(&fatalError{env: vm.env, msg: err})
@@ -1792,7 +1792,7 @@ func (vm *VM) run() (Addr, bool) {
 			if rv.IsValid() {
 				v = rv.Interface()
 			}
-			err := vm.renderer.Show(vm.env, v, Context(c), vm.conv)
+			err := vm.renderer.Show(vm.env, v, Context(c))
 			if err != nil {
 				panic(outError{err})
 			}

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -291,7 +291,7 @@ func (vm *VM) run() (Addr, bool) {
 				if fn.Macro {
 					call.renderer = vm.renderer
 					if b == ReturnString {
-						vm.renderer = vm.renderer.WithOut(&macroOutBuffer{})
+						vm.renderer = newRenderer(&macroOutBuffer{}, nil)
 					} else if ast.Format(b) != fn.Format {
 						vm.renderer = vm.renderer.WithConversion(fn.Format, ast.Format(b))
 					}
@@ -322,7 +322,7 @@ func (vm *VM) run() (Addr, bool) {
 				vm.moreGeneralStack()
 			}
 			if b == ReturnString {
-				vm.renderer = vm.renderer.WithOut(&macroOutBuffer{})
+				vm.renderer = newRenderer(&macroOutBuffer{}, nil)
 			} else if ast.Format(b) != fn.Format {
 				vm.renderer = vm.renderer.WithConversion(fn.Format, ast.Format(b))
 			}

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -1786,7 +1786,7 @@ func (vm *VM) run() (Addr, bool) {
 			if rv.IsValid() {
 				v = rv.Interface()
 			}
-			err := vm.renderer.Show(v, Context(c))
+			err := vm.renderer.Show(vm.env, v, Context(c))
 			if err != nil {
 				panic(outError{err})
 			}

--- a/internal/runtime/vm.go
+++ b/internal/runtime/vm.go
@@ -94,7 +94,6 @@ type VM struct {
 	env      *env                 // execution environment.
 	envArg   reflect.Value        // execution environment as argument.
 	renderer *renderer            // renderer
-	conv     Converter            // Markdown converter
 	calls    []callFrame          // call stack frame.
 	cases    []reflect.SelectCase // select cases.
 	panic    *PanicError          // panic.
@@ -122,7 +121,6 @@ func (vm *VM) Reset() {
 	vm.env = &env{}
 	vm.envArg = reflect.ValueOf(vm.env)
 	vm.renderer = nil
-	vm.conv = nil
 	if vm.calls != nil {
 		vm.calls = vm.calls[:0]
 	}
@@ -195,7 +193,7 @@ func (vm *VM) SetContext(ctx context.Context) {
 // SetRenderer must not be called after vm has been started.
 func (vm *VM) SetRenderer(out io.Writer, conv Converter) {
 	vm.renderer = newRenderer(out)
-	vm.conv = conv
+	vm.env.conv = conv
 }
 
 // SetPrint sets the "print" builtin function.

--- a/internal/runtime/vm.go
+++ b/internal/runtime/vm.go
@@ -907,7 +907,7 @@ func (c *callable) Value(renderer *renderer, env *env) reflect.Value {
 	c.value = reflect.MakeFunc(fn.Type, func(args []reflect.Value) []reflect.Value {
 		nvm := create(env)
 		if fn.Macro {
-			renderer = renderer.WithOut(&macroOutBuffer{})
+			renderer = newRenderer(&macroOutBuffer{}, nil)
 		}
 		nvm.renderer = renderer
 		nOut := fn.Type.NumOut()

--- a/internal/runtime/vm.go
+++ b/internal/runtime/vm.go
@@ -5,7 +5,6 @@
 package runtime
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -736,19 +735,6 @@ type Registers struct {
 	General []reflect.Value
 }
 
-// macroOutBuffer is used in CallMacro and CallIndirect instructions to buffer
-// the out of a macro call and convert it to a string in Return instructions.
-type macroOutBuffer struct {
-	strings.Builder
-}
-
-// markdownOutBuffer is used in CallMacro and CallIndirect instructions to
-// buffer the out of a macro call and convert it from Markdown to HTML in Return
-// instructions.
-type markdownOutBuffer struct {
-	bytes.Buffer
-}
-
 type NativeFunction struct {
 	pkg         string        // package.
 	name        string        // name.
@@ -916,7 +902,7 @@ func (c *callable) Value(renderer *renderer, env *env) reflect.Value {
 	c.value = reflect.MakeFunc(fn.Type, func(args []reflect.Value) []reflect.Value {
 		nvm := create(env)
 		if fn.Macro {
-			renderer = newRenderer(&macroOutBuffer{})
+			renderer = newRenderer(&strings.Builder{})
 		}
 		nvm.renderer = renderer
 		nOut := fn.Type.NumOut()
@@ -952,7 +938,7 @@ func (c *callable) Value(renderer *renderer, env *env) reflect.Value {
 			panic(err)
 		}
 		if fn.Macro {
-			b := renderer.Out().(*macroOutBuffer)
+			b := renderer.Out().(*strings.Builder)
 			nvm.setString(1, b.String())
 		}
 		r = [4]int8{1, 1, 1, 1}

--- a/internal/runtime/vm.go
+++ b/internal/runtime/vm.go
@@ -191,7 +191,7 @@ func (vm *VM) SetContext(ctx context.Context) {
 //
 // SetRenderer must not be called after vm has been started.
 func (vm *VM) SetRenderer(out io.Writer, conv Converter) {
-	vm.renderer = newRenderer(vm.env, out, conv)
+	vm.renderer = newRenderer(out, conv)
 }
 
 // SetPrint sets the "print" builtin function.

--- a/internal/runtime/vm.go
+++ b/internal/runtime/vm.go
@@ -5,6 +5,7 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -743,6 +744,13 @@ type macroOutBuffer struct {
 	strings.Builder
 }
 
+// markdownOutBuffer is used in CallMacro and CallIndirect instructions to
+// buffer the out of a macro call and convert it from Markdown to HTML in Return
+// instructions.
+type markdownOutBuffer struct {
+	bytes.Buffer
+}
+
 type NativeFunction struct {
 	pkg         string        // package.
 	name        string        // name.
@@ -948,10 +956,6 @@ func (c *callable) Value(renderer *renderer, env *env) reflect.Value {
 		if fn.Macro {
 			b := renderer.Out().(*macroOutBuffer)
 			nvm.setString(1, b.String())
-			err := renderer.Close()
-			if err != nil {
-				panic(&fatalError{env: env, msg: err})
-			}
 		}
 		r = [4]int8{1, 1, 1, 1}
 		for _, result := range results {


### PR DESCRIPTION
```
This change refactors the macro call handling, focusing on improvements
to the renderer implementation.

  * The conversion from Markdown to HTML has been moved out of the
    renderer. Similarly, the environment is now passed as an argument to
    the 'renderer.Show' method.  

  * When returning from a macro, the second operator of the operation
    invoking the macro is checked to determine whether to convert
    Markdown to HTML or return a plain string, consistent with the
    behavior during invocation. This change eliminates the need for
    specific data types previously used for this purpose.
  
  * The implementation of the ConvertString operation has been
    simplified to remove its dependency on the renderer.  

As a result, macro calls and conversion to string are now simpler,
clearer, and more efficient.
```