### PR TITLE
internal/compiler: fix emitting of method calls 

### DIFF
--- a/internal/compiler/emitter.go
+++ b/internal/compiler/emitter.go
@@ -579,11 +579,10 @@ func (em *emitter) emitCallNode(call *ast.Call, goStmt bool, deferStmt bool, toF
 		name := call.Func.(*ast.Selector).Ident
 		s := em.fb.makeStringValue(name)
 		em.fb.emitMethodValue(s, rcvr, method, call.Func.Pos())
-		call.Args = append([]ast.Expression{rcvrExpr}, call.Args...)
 		stackShift := em.fb.currentStackShift()
 		opts := callOptions{
 			predefined:    true,
-			receiverAsArg: true,
+			receiverAsArg: false,
 			callHasDots:   call.IsVariadic,
 		}
 		regs, types := em.prepareCallParameters(funTi.Type, call.Args, opts)

--- a/test/misc/program_test.go
+++ b/test/misc/program_test.go
@@ -586,10 +586,7 @@ func TestIssue967(t *testing.T) {
 		import "com/interop"
 
 		func main() {
-			p := interop.GetPrinter()
-			p.Print(interop.Value)  // this does not work
-			//pp := p.Print         // this works
-			//pp(interop.Value)
+			interop.GetPrinter().Print(interop.Value)
 		}`
 		fsys := fstest.Files{"main.go": main}
 		program, err := scriggo.Build(fsys, &scriggo.BuildOptions{Packages: packages})

--- a/test/misc/program_test.go
+++ b/test/misc/program_test.go
@@ -605,8 +605,9 @@ func TestIssue967(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected run error: %s ", err)
 		}
-		if got := printBuf.String(); got != "15" {
-			t.Fatalf(`expected %q, got "15 (int)"`, got)
+		const expected = "15 (int)"
+		if got := printBuf.String(); got != expected {
+			t.Fatalf(`expected %q, got %q`, expected, got)
 		}
 	})
 }


### PR DESCRIPTION
## Commit Message

```
internal/compiler: fix emitting of receiver in method calls

This commit fixes the emitting of method calls, where the receiver of
the method call was erroneously placed as first "general" argument in
the call stack, causing an incorrect stack shift and altering the
parameters received from the called method.

Also adds tests on this.

Fix #967.
```