### PR TITLE
cmd/scriggo: add `-http` option to `scriggo serve`

### DIFF
--- a/cmd/scriggo/help.go
+++ b/cmd/scriggo/help.go
@@ -195,7 +195,7 @@ Examples:
 `
 
 const helpServe = `
-usage: scriggo serve [-S n] [--metrics] [--disable-livereload]
+usage: scriggo serve [-S n] [--metrics] [--disable-livereload] [-http host[:port]]
 
 Serve runs a web server and serves the template rooted at the current
 directory. It is useful to learn Scriggo templates.
@@ -232,6 +232,18 @@ The --metrics flags prints metrics about execution time.
 
 The --disable-livereload flag disables LiveReload, preventing automatic page
 reloads in the browser.
+
+The -http flag configures the address the server listens on:
+
+	-http host[:port]   listen address (default "localhost:8080")
+
+Examples:
+
+	scriggo serve -http example.com:80
+
+	scriggo serve -http example.com
+
+	scriggo serve -http :80
 `
 
 const helpScriggofile = `

--- a/cmd/scriggo/httpflag_test.go
+++ b/cmd/scriggo/httpflag_test.go
@@ -1,0 +1,60 @@
+// Copyright 2025 The Scriggo Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import "testing"
+
+func TestParseAddr(t *testing.T) {
+	const (
+		defaultHost = "localhost"
+		defaultPort = "8080"
+	)
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "hostAndPort",
+			input: "example.com:80",
+			want:  "example.com:80",
+		},
+		{
+			name:  "hostOnly",
+			input: "example.com",
+			want:  "example.com" + ":" + defaultPort,
+		},
+		{
+			name:  "portOnly",
+			input: ":80",
+			want:  defaultHost + ":80",
+		},
+		{name: "empty", input: "", wantErr: true},
+		{name: "colonOnly", input: ":", wantErr: true},
+		{name: "zeroPort", input: ":0", wantErr: true},
+		{name: "largePort", input: ":99999", wantErr: true},
+		{name: "invalidPort", input: "bad:port", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addr, err := parseAddr(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got no error", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected nil error for %q, got %v", tt.input, err)
+			}
+			if addr != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, addr)
+			}
+		})
+	}
+}

--- a/cmd/scriggo/main.go
+++ b/cmd/scriggo/main.go
@@ -239,17 +239,22 @@ var commands = map[string]func(){
 		s := flag.Int("S", 0, "print assembly listing. n determines the length of Text instructions.")
 		metrics := flag.Bool("metrics", false, "print metrics about file executions.")
 		disableLiveReload := flag.Bool("disable-livereload", false, "disable LiveReload.")
+		httpValue := flag.String("http", "", "set the listen address of the HTTP server.")
 		flag.Parse()
 		asm := -2 // -2: no assembler
+		httpFlagSet := false
 		flag.Visit(func(f *flag.Flag) {
-			if f.Name == "S" {
+			switch f.Name {
+			case "S":
 				asm = *s
 				if asm < -1 {
 					asm = -1
 				}
+			case "http":
+				httpFlagSet = true
 			}
 		})
-		err := serve(asm, *metrics, *disableLiveReload)
+		err := serve(asm, *metrics, *disableLiveReload, *httpValue, httpFlagSet)
 		if err != nil {
 			exitError("%s", err)
 		}


### PR DESCRIPTION
```
cmd/scriggo: add `-http` option to `scriggo serve`

This change adds the `-http` option to the `scriggo serve` command to 
specify the host and port on which the server listens.
```