### PR TITLE
internal/runtime: handle deletion of unhashable types as panics

### DIFF
--- a/internal/runtime/errors.go
+++ b/internal/runtime/errors.go
@@ -173,7 +173,7 @@ func (vm *VM) convertPanic(msg interface{}) error {
 		}
 	case OpDelete:
 		if err, ok := msg.(runtime.Error); ok {
-			if s := err.Error(); strings.HasPrefix(s, "runtime error: hash of unhashable type ") {
+			if s := err.Error(); strings.HasPrefix(s, "hash of unhashable type: ") {
 				return vm.newPanic(runtimeError(s))
 			}
 		}

--- a/test/compare/testdata/misc/runtime_panic.go
+++ b/test/compare/testdata/misc/runtime_panic.go
@@ -311,7 +311,7 @@ func test18() {
 }
 
 func test19() {
-	defer recoverRuntimePanic("runtime error: hash of unhashable type []int")
+	defer recoverRuntimePanic("hash of unhashable type: []int")
 	m := map[interface{}]int{}
 	delete(m, []int{})
 }


### PR DESCRIPTION
```
internal/runtime: handle deletion of unhashable types as panics

Previously, deleting an unhashable type from a map caused a fatal
runtime error instead of triggering a panic in the interpreted program
or template.

As a result, the scriggo serve command exited with a failure and printed
a stack trace instead of returning the panic message to the client.

This issue was caused by a change in the Go runtime that modified the
panic message returned in this circumstance.

Note that this fix allows 'test/compare/testdata/fixedbugs/issue811.go'
to pass.
```