### PR TITLE
internal/compiler: fix imports without extensions in templates

### DIFF
--- a/internal/compiler/emitter_statements.go
+++ b/internal/compiler/emitter_statements.go
@@ -5,7 +5,6 @@
 package compiler
 
 import (
-	"path/filepath"
 	"reflect"
 
 	"github.com/open2b/scriggo/ast"
@@ -86,7 +85,7 @@ func (em *emitter) emitNodes(nodes []ast.Node) {
 				// Import a template file.
 				// Precompiled packages have been already handled by the type
 				// checker and should be ignored by the emitter.
-				if ext := filepath.Ext(node.Path); ext != "" {
+				if node.Tree != nil {
 					inits := em.emitImport(node, true)
 					if len(inits) > 0 && !em.alreadyInitializedTemplatePkgs[node.Tree.Path] {
 						for _, initFunc := range inits {

--- a/test/compare/testdata/templates/imports-without-extentions.dir/bar
+++ b/test/compare/testdata/templates/imports-without-extentions.dir/bar
@@ -1,0 +1,1 @@
+{% macro Bar %}I'm bar{% end %}

--- a/test/compare/testdata/templates/imports-without-extentions.dir/foo.html
+++ b/test/compare/testdata/templates/imports-without-extentions.dir/foo.html
@@ -1,0 +1,1 @@
+{% macro Foo %}I'm foo.html{% end %}

--- a/test/compare/testdata/templates/imports-without-extentions.dir/index.html
+++ b/test/compare/testdata/templates/imports-without-extentions.dir/index.html
@@ -1,0 +1,5 @@
+{% import "foo.html" %}
+{% import "bar" %}
+I'm index.html
+{{ Foo() }}
+{{ Bar() }}

--- a/test/compare/testdata/templates/imports-without-extentions.golden
+++ b/test/compare/testdata/templates/imports-without-extentions.golden
@@ -1,0 +1,3 @@
+I'm index.html
+I'm foo.html
+I&#39;m bar

--- a/test/compare/testdata/templates/imports-without-extentions.html
+++ b/test/compare/testdata/templates/imports-without-extentions.html
@@ -1,0 +1,1 @@
+{# renderdir #}


### PR DESCRIPTION
## Commit message

```
internal/compiler: fix imports without extensions in templates

Currently, in templates, the emitter incorrectly checks whether an
import refers to a precompiled package or a template file, based solely
on whether the import path has an extension or not. This becomes
problematic when attempting to import a template file without an
extension, as the emitter treats it as a precompiled package, causing
Scriggo to panic.

This commit fixes the problem by verifying whether the tree is nil or
not. This is how we already determine whether a node is precompiled. It
also adds a test that currently causes Scriggo to panic, but with this
change now passes correctly.

Thanks to @phihos, who originally filed a PR on Scriggo (#977),
identified the issue, and proposed a change that was later implemented
in this commit.
```