### PR TITLE
cmd/scriggo: exit with status code 2 when running just `scriggo`

### DIFF
--- a/cmd/scriggo/main.go
+++ b/cmd/scriggo/main.go
@@ -59,7 +59,7 @@ func main() {
 	// No command provided.
 	if len(os.Args) == 1 {
 		flag.Usage()
-		exit(0)
+		exit(2)
 		return
 	}
 


### PR DESCRIPTION
Also see issue #1012.

## Commit message

```
cmd/scriggo: exit with status code 2 when running just `scriggo`

Currently, when 'scriggo' is run without any other
parameters/subcommands, it returns exit code 0.

This is generally not expected, as it represents an error in which
nothing has been executed.

The go command, for example, returns 2 in this case.

So this commit ensures that in this case, scriggo exits with exit code
2, which also appears to be the behavior of the Bash builtins.

This appears to be the only case in the Scriggo command where a success
status was returned when the command was called with incorrect
arguments, so it has been fixed separately in this commit; for all other
cases, see issue #1012.
```