### PR TITLE
#1017 - Add Go module filenames into stack traces

### DIFF
--- a/internal/compiler/checker_dependencies_test.go
+++ b/internal/compiler/checker_dependencies_test.go
@@ -741,7 +741,7 @@ var cases = map[string]struct {
 func TestDependencies(t *testing.T) {
 	for name, cas := range cases {
 		t.Run(name, func(t *testing.T) {
-			tree, err := parseSource([]byte(cas.src), false)
+			tree, err := parseSource("", []byte(cas.src), false)
 			if err != nil {
 				t.Fatalf("parsing error: %s", err)
 			}

--- a/internal/compiler/checker_package_test.go
+++ b/internal/compiler/checker_package_test.go
@@ -42,7 +42,7 @@ func TestInitializationLoop(t *testing.T) {
 	}
 	for name, cas := range cases {
 		t.Run(name, func(t *testing.T) {
-			tree, err := parseSource([]byte(cas.src), false)
+			tree, err := parseSource("", []byte(cas.src), false)
 			if err != nil {
 				t.Fatalf("parsing error: %s", err)
 			}
@@ -296,7 +296,7 @@ func TestPackageOrdering(t *testing.T) {
 	}
 	for name, cas := range cases {
 		t.Run(name, func(t *testing.T) {
-			tree, err := parseSource([]byte(cas.src), false)
+			tree, err := parseSource("", []byte(cas.src), false)
 			if err != nil {
 				t.Fatalf("parsing error: %s", err)
 			}

--- a/internal/compiler/checker_test.go
+++ b/internal/compiler/checker_test.go
@@ -1837,7 +1837,7 @@ func TestCheckerStatements(t *testing.T) {
 					}
 				}
 			}()
-			tree, err := parseSource([]byte(src), true)
+			tree, err := parseSource("", []byte(src), true)
 			if err != nil {
 				t.Errorf("source: %s returned parser error: %s", src, err.Error())
 				return
@@ -2376,7 +2376,7 @@ func TestTypechecker_MaxIndex(t *testing.T) {
 	compilation := newCompilation(nil)
 	tc := newTypechecker(compilation, "", checkerOptions{}, nil)
 	for src, expected := range cases {
-		tree, err := parseSource([]byte(src), true)
+		tree, err := parseSource("", []byte(src), true)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2498,7 +2498,7 @@ func TestFunctionUpVars(t *testing.T) {
 	for src, expected := range cases {
 		compilation := newCompilation(nil)
 		tc := newTypechecker(compilation, "", checkerOptions{}, nil)
-		tree, err := parseSource([]byte(src), true)
+		tree, err := parseSource("", []byte(src), true)
 		if err != nil {
 			t.Error(err)
 			continue

--- a/internal/compiler/parser.go
+++ b/internal/compiler/parser.go
@@ -177,7 +177,7 @@ func (p *parsing) next() token {
 
 // parseSource parses a program and returns its tree.
 // If noPackage is true, it does not expect a package statement.
-func parseSource(src []byte, noPackage bool) (tree *ast.Tree, err error) {
+func parseSource(name string, src []byte, noPackage bool) (tree *ast.Tree, err error) {
 
 	tree = ast.NewTree("", nil, ast.FormatText)
 
@@ -192,6 +192,7 @@ func parseSource(src []byte, noPackage bool) (tree *ast.Tree, err error) {
 		if r := recover(); r != nil {
 			if e, ok := r.(*SyntaxError); ok {
 				tree = nil
+				e.path = name
 				err = e
 			} else {
 				panic(r)
@@ -210,16 +211,22 @@ func parseSource(src []byte, noPackage bool) (tree *ast.Tree, err error) {
 
 	if len(p.ancestors) == 1 {
 		if !noPackage && len(tree.Nodes) == 0 {
-			panic(syntaxError(tok.pos, "expected 'package', found 'EOF'"))
+			se := syntaxError(tok.pos, "expected 'package', found 'EOF'")
+			se.path = name
+			panic(se)
 		}
 	} else {
 		switch p.ancestors[1].(type) {
 		case *ast.Package:
 		case *ast.Label:
-			return nil, syntaxError(tok.pos, "missing statement after label")
+			se := syntaxError(tok.pos, "missing statement after label")
+			se.path = name
+			return nil, se
 		default:
 			if len(p.ancestors) > 2 {
-				return nil, syntaxError(tok.pos, "unexpected EOF, expecting }")
+				se := syntaxError(tok.pos, "unexpected EOF, expecting }")
+				se.path = name
+				return nil, se
 			}
 		}
 	}

--- a/internal/compiler/parser_program.go
+++ b/internal/compiler/parser_program.go
@@ -150,7 +150,7 @@ func parsePackage(fsys fs.FS, dir string) (*ast.Tree, error) {
 	if err != nil {
 		return nil, err
 	}
-	tree, err := parseSource(src, false)
+	tree, err := parseSource(name, src, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/compiler/parser_test.go
+++ b/internal/compiler/parser_test.go
@@ -1459,7 +1459,7 @@ func fileTests() map[string]struct {
 
 func TestGoContextTrees(t *testing.T) {
 	for _, tree := range goContextTreeTests {
-		node, err := parseSource([]byte(tree.src), true)
+		node, err := parseSource("", []byte(tree.src), true)
 		if err != nil {
 			t.Errorf("source: %q, %s\n", tree.src, err)
 			continue
@@ -1488,7 +1488,7 @@ func TestShebang(t *testing.T) {
 		if test.template {
 			_, _, err = ParseTemplateSource([]byte(test.src), ast.FormatText, false, false)
 		} else {
-			_, err = parseSource([]byte(test.src), false)
+			_, err = parseSource("", []byte(test.src), false)
 		}
 		if err == nil {
 			if test.err != "" {


### PR DESCRIPTION
This PR adds the filename into the stack trace error returned from `scriggo.Build()` - without the PR, stack traces miss the filename (e.g. it's just the column and position, like `:3:1: syntax error: non-declaration statement outside function body`.

To accomplish this, I added a `name` argument to `parseSource()` so the error can be constructed with the filename when we have access to it.