### PR TITLE
#1018 Fix: Handle dashes in Go version

### DIFF
--- a/cmd/scriggo/util.go
+++ b/cmd/scriggo/util.go
@@ -195,6 +195,12 @@ func goBaseVersion(v string) string {
 	if i := strings.Index(v, "rc"); i >= 0 {
 		v = v[:i]
 	}
+
+	// On Linux, Go might be built by default with extra args, separated by -, like "go1.26.0-X:nodwarf5"
+	if i := strings.Index(v, "-"); i >= 0 {
+		v = v[:i]
+	}
+
 	v = v[4:]
 	f, err := strconv.ParseFloat(v, 32)
 	if err != nil {


### PR DESCRIPTION
When running the scriggo command, it parses the Go runtime's version string. The version string might have non-alphanumeric characters after the semver numbers themselves on Linux (on Arch / EndeavourOS, specifically), making the tool crash when used with a Go build with such a version number. This PR fixes this by trimming the right side of the string beyond the semver number if it detects a dash.