### PR TITLE
internal/compiler: fix panic in case of limit exceeded in `using` stmt

### DIFF
--- a/internal/compiler/checker_statements.go
+++ b/internal/compiler/checker_statements.go
@@ -1366,12 +1366,12 @@ func (tc *typechecker) explodeUsingStatement(using *ast.Using, iteaIdent string)
 	switch typ := using.Type.(type) {
 	case *ast.Identifier:
 		itea = ast.NewCall(nil,
-			ast.NewFunc(nil, nil,
+			ast.NewFunc(using.Position, nil,
 				ast.NewFuncType(nil, true, nil, []*ast.Parameter{ast.NewParameter(nil, typ)}, false),
 				using.Body, false, using.Format),
 			nil, false)
 	case *ast.FuncType:
-		itea = ast.NewFunc(nil, nil, typ, using.Body, false, using.Format)
+		itea = ast.NewFunc(using.Position, nil, typ, using.Body, false, using.Format)
 	default:
 		panic(internalError("the parser should not allow this"))
 	}

--- a/test/misc/templates_test.go
+++ b/test/misc/templates_test.go
@@ -904,10 +904,9 @@ func TestRecoveredOutError(t *testing.T) {
 	}
 }
 
-// TestUsingLimitExceededError tests whether a 'LimitExceededError' error occurs
-// within a "using" statement, this doesn't cause Scriggo to panic, but rather
-// contains the line and position of the "using" statement that causes the limit
-// to be exceeded.
+// TestUsingLimitExceededError tests whether a 'LimitExceededError' error,
+// occurred within a "using" statement, contains the line and position of the
+// "using" statement that causes the limit to be exceeded.
 func TestUsingLimitExceededError(t *testing.T) {
 
 	t.Run("limit exceeded error with 'using' (identifier)", func(t *testing.T) {

--- a/test/misc/templates_test.go
+++ b/test/misc/templates_test.go
@@ -909,6 +909,7 @@ func TestRecoveredOutError(t *testing.T) {
 // contains the line and position of the "using" statement that causes the limit
 // to be exceeded.
 func TestUsingLimitExceededError(t *testing.T) {
+
 	t.Run("limit exceeded error with 'using' (identifier)", func(t *testing.T) {
 		var indexHTML strings.Builder
 		indexHTML.WriteString("\n\n\n\t\t\t\t{% show itea; using %}\n")
@@ -932,6 +933,7 @@ func TestUsingLimitExceededError(t *testing.T) {
 			t.Fatalf("expected error %q, got %q", expected, be.Error())
 		}
 	})
+
 	t.Run("limit exceeded error with 'using' (macro)", func(t *testing.T) {
 		var indexHTML strings.Builder
 		indexHTML.WriteString("\n\n\n\t\t\t\t{% show itea(\"hello\"); using macro(name string) %}\n")
@@ -955,4 +957,5 @@ func TestUsingLimitExceededError(t *testing.T) {
 			t.Fatalf("expected error %q, got %q", expected, be.Error())
 		}
 	})
+
 }

--- a/test/misc/templates_test.go
+++ b/test/misc/templates_test.go
@@ -903,3 +903,34 @@ func TestRecoveredOutError(t *testing.T) {
 		t.Fatalf("expecting no error, got error %v", err)
 	}
 }
+
+// TestUsingLimitExceededError tests whether a 'LimitExceededError' error occurs
+// within a "using" statement, this doesn't cause Scriggo to panic, but rather
+// contains the line and position of the "using" statement that causes the limit
+// to be exceeded.
+func TestUsingLimitExceededError(t *testing.T) {
+	t.Run("limit exceeded error with using (identifier)", func(t *testing.T) {
+		var indexHTML strings.Builder
+		indexHTML.WriteString("\n\n\n\t\t\t\t{% show itea; using %}\n")
+		for i := range 257 {
+			_, _ = fmt.Fprintf(&indexHTML, "{{ `string %d` }}", i)
+		}
+		indexHTML.WriteString("{% end using %}")
+		fsys := fstest.Files{
+			"index.html": indexHTML.String(),
+		}
+		_, err := scriggo.BuildTemplate(fsys, "index.html", nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		be, ok := err.(*scriggo.BuildError)
+		if !ok {
+			t.Fatalf("expected *scriggo.BuildError, got %T", err)
+		}
+		const expected = "index.html:4:19: string values count exceeded 256"
+		if be.Error() != expected {
+			t.Fatalf("expected error %q, got %q", expected, be.Error())
+		}
+	})
+	// TODO: add the other test on using macro
+}

--- a/test/misc/templates_test.go
+++ b/test/misc/templates_test.go
@@ -909,7 +909,7 @@ func TestRecoveredOutError(t *testing.T) {
 // contains the line and position of the "using" statement that causes the limit
 // to be exceeded.
 func TestUsingLimitExceededError(t *testing.T) {
-	t.Run("limit exceeded error with using (identifier)", func(t *testing.T) {
+	t.Run("limit exceeded error with 'using' (identifier)", func(t *testing.T) {
 		var indexHTML strings.Builder
 		indexHTML.WriteString("\n\n\n\t\t\t\t{% show itea; using %}\n")
 		for i := range 257 {
@@ -932,5 +932,27 @@ func TestUsingLimitExceededError(t *testing.T) {
 			t.Fatalf("expected error %q, got %q", expected, be.Error())
 		}
 	})
-	// TODO: add the other test on using macro
+	t.Run("limit exceeded error with 'using' (macro)", func(t *testing.T) {
+		var indexHTML strings.Builder
+		indexHTML.WriteString("\n\n\n\t\t\t\t{% show itea(\"hello\"); using macro(name string) %}\n")
+		for i := range 257 {
+			_, _ = fmt.Fprintf(&indexHTML, "{{ `string %d` }}", i)
+		}
+		indexHTML.WriteString("{% end using %}")
+		fsys := fstest.Files{
+			"index.html": indexHTML.String(),
+		}
+		_, err := scriggo.BuildTemplate(fsys, "index.html", nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		be, ok := err.(*scriggo.BuildError)
+		if !ok {
+			t.Fatalf("expected *scriggo.BuildError, got %T", err)
+		}
+		const expected = "index.html:4:28: string values count exceeded 256"
+		if be.Error() != expected {
+			t.Fatalf("expected error %q, got %q", expected, be.Error())
+		}
+	})
 }


### PR DESCRIPTION
## Commit message

```
internal/compiler: fix panic in case of limit exceeded in `using` stmt

Currently, when a limit exceeded error occurs within a 'using'
statement, it causes Scriggo to panic because the error contains a nil
position, as the position is taken from a dummy function with no
specified position.

This commit fixes the bug by making the dummy function have the same
position of the 'using' statement (both in the cases when 'using' has an
identifier and a function type), which will then be the position
reported in the limit exceeded error.
```